### PR TITLE
style: reformat frontend with Prettier

### DIFF
--- a/web/.prettierignore
+++ b/web/.prettierignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+out
+dist
+build
+*.min.js
+*.min.css
+package-lock.json

--- a/web/.prettierignore
+++ b/web/.prettierignore
@@ -6,3 +6,4 @@ build
 *.min.js
 *.min.css
 package-lock.json
+components/ui/

--- a/web/.prettierrc
+++ b/web/.prettierrc
@@ -1,0 +1,10 @@
+{
+	"semi": true,
+	"trailingComma": "es5",
+	"singleQuote": false,
+	"printWidth": 140,
+	"tabWidth": 4,
+	"useTabs": true,
+	"arrowParens": "always",
+	"endOfLine": "lf"
+}

--- a/web/app/auth/anilist/page.tsx
+++ b/web/app/auth/anilist/page.tsx
@@ -1,15 +1,16 @@
-import React, {Suspense} from "react";
-import {ProtectedRoute} from "@/components/contexts/route-accessibility";
-import {Auth} from "@/app/auth/auth";
-import {CLIENT_ID_PLACEHOLDER, REDIRECT_URL_PLACEHOLDER} from "@/components/global-config";
+import React, { Suspense } from "react";
+import { ProtectedRoute } from "@/components/contexts/route-accessibility";
+import { Auth } from "@/app/auth/auth";
+import { CLIENT_ID_PLACEHOLDER, REDIRECT_URL_PLACEHOLDER } from "@/components/global-config";
 
 export default function AuthAniList() {
 	return (
 		<ProtectedRoute>
 			<Suspense>
-				<Auth service={"anilist"}
-					  authUrl={`https://anilist.co/api/v2/oauth/authorize?client_id=${CLIENT_ID_PLACEHOLDER}&redirect_uri=${REDIRECT_URL_PLACEHOLDER}/auth/anilist&response_type=code`}>
-				</Auth>
+				<Auth
+					service={"anilist"}
+					authUrl={`https://anilist.co/api/v2/oauth/authorize?client_id=${CLIENT_ID_PLACEHOLDER}&redirect_uri=${REDIRECT_URL_PLACEHOLDER}/auth/anilist&response_type=code`}
+				></Auth>
 			</Suspense>
 		</ProtectedRoute>
 	);

--- a/web/app/auth/auth.tsx
+++ b/web/app/auth/auth.tsx
@@ -1,51 +1,51 @@
-"use client"
+"use client";
 
-import {useRouter, useSearchParams} from "next/navigation";
-import {useAuth} from "@/components/contexts/auth-context";
-import React, {useEffect, useRef} from "react";
-import authorize, {info} from "@/components/api/auth-api";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useAuth } from "@/components/contexts/auth-context";
+import React, { useEffect, useRef } from "react";
+import authorize, { info } from "@/components/api/auth-api";
 import LoadingPage from "@/components/loading-skeletons/loading-page";
-import {CLIENT_ID_PLACEHOLDER, REDIRECT_URL_PLACEHOLDER} from "@/components/global-config";
+import { CLIENT_ID_PLACEHOLDER, REDIRECT_URL_PLACEHOLDER } from "@/components/global-config";
 
-export function Auth({service, authUrl}: { service: string, authUrl: string }) {
-	const searchParams = useSearchParams()
-	const router = useRouter()
+export function Auth({ service, authUrl }: { service: string; authUrl: string }) {
+	const searchParams = useSearchParams();
+	const router = useRouter();
 	const host = window.location.protocol + "//" + window.location.host;
 	const authUrlRef = useRef(authUrl);
-	const {user, token} = useAuth()
+	const { user, token } = useAuth();
 
 	useEffect(() => {
 		if (searchParams.has("code")) {
-			const code = searchParams.get("code")
+			const code = searchParams.get("code");
 			authorize(service, user, token, code)
-				.then(response => {
+				.then((response) => {
 					if (response.error) throw new Error(response.error);
 					if (response.data) {
-						return Promise.reject(response.data.message)
+						return Promise.reject(response.data.message);
 					}
 				})
-				.catch(err => {
+				.catch((err) => {
 					console.error(err);
 				})
 				.finally(() => {
-					router.push(`/user/${user}`)
+					router.push(`/user/${user}`);
 				});
 		} else {
 			info(service, token)
-				.then(response => {
+				.then((response) => {
 					if (response.error) throw new Error(response.error);
-					if (!response.data) throw new Error("Faulty response")
+					if (!response.data) throw new Error("Faulty response");
 					authUrlRef.current = authUrlRef.current
 						.replace(REDIRECT_URL_PLACEHOLDER, host)
 						.replace(CLIENT_ID_PLACEHOLDER, response.data.clientId);
 					router.push(authUrlRef.current);
 				})
-				.catch(err => {
+				.catch((err) => {
 					console.error(err);
 					router.push(`/user/${user}`);
-				})
+				});
 		}
-	}, [user, token, router, searchParams, service, host])
+	}, [user, token, router, searchParams, service, host]);
 
-	return <LoadingPage/>
+	return <LoadingPage />;
 }

--- a/web/app/auth/trakt/page.tsx
+++ b/web/app/auth/trakt/page.tsx
@@ -1,15 +1,16 @@
-import {ProtectedRoute} from "@/components/contexts/route-accessibility";
-import React, {Suspense} from "react";
-import {Auth} from "@/app/auth/auth";
-import {CLIENT_ID_PLACEHOLDER, REDIRECT_URL_PLACEHOLDER} from "@/components/global-config";
+import { ProtectedRoute } from "@/components/contexts/route-accessibility";
+import React, { Suspense } from "react";
+import { Auth } from "@/app/auth/auth";
+import { CLIENT_ID_PLACEHOLDER, REDIRECT_URL_PLACEHOLDER } from "@/components/global-config";
 
 export default function AuthTrakt() {
 	return (
 		<ProtectedRoute>
 			<Suspense>
-				<Auth service={"trakt"}
-					  authUrl={`https://api.trakt.tv/oauth/authorize?response_type=code&client_id=${CLIENT_ID_PLACEHOLDER}&redirect_uri=${REDIRECT_URL_PLACEHOLDER}/auth/trakt`}>
-				</Auth>
+				<Auth
+					service={"trakt"}
+					authUrl={`https://api.trakt.tv/oauth/authorize?response_type=code&client_id=${CLIENT_ID_PLACEHOLDER}&redirect_uri=${REDIRECT_URL_PLACEHOLDER}/auth/trakt`}
+				></Auth>
 			</Suspense>
 		</ProtectedRoute>
 	);

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -1,21 +1,23 @@
-import {Card, CardHeader} from "@/components/ui/card";
-import {cn} from "@/lib/utils";
-import {ProtectedRoute} from "@/components/contexts/route-accessibility";
+import { Card, CardHeader } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { ProtectedRoute } from "@/components/contexts/route-accessibility";
 
 export default function Dashboard() {
 	return (
 		<ProtectedRoute>
 			<div className={"flex justify-center items-center"}>
-				<Card className={cn(
-					"w-full max-w-md rounded-2xl p-4 pt-6 pb-6 z-50",
-					"bg-background/80 backdrop-blur-md border border-border/100 shadow-lg",
-					"transition-all duration-200 ease-in-out"
-				)}>
+				<Card
+					className={cn(
+						"w-full max-w-md rounded-2xl p-4 pt-6 pb-6 z-50",
+						"bg-background/80 backdrop-blur-md border border-border/100 shadow-lg",
+						"transition-all duration-200 ease-in-out"
+					)}
+				>
 					<CardHeader>
 						<h2>This is a dashboard. Believe it or not</h2>
 					</CardHeader>
 				</Card>
 			</div>
 		</ProtectedRoute>
-	)
+	);
 }

--- a/web/app/forgot-password/page.tsx
+++ b/web/app/forgot-password/page.tsx
@@ -1,3 +1,3 @@
 export default function ForgotPassword() {
-	return <div>hahaha</div>
+	return <div>hahaha</div>;
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4,146 +4,145 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-    --color-background: var(--background);
-    --color-foreground: var(--foreground);
-    --font-sans: var(--font-geist-sans);
-    --font-mono: var(--font-geist-mono);
-    --color-sidebar-ring: var(--sidebar-ring);
-    --color-sidebar-border: var(--sidebar-border);
-    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-    --color-sidebar-accent: var(--sidebar-accent);
-    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-    --color-sidebar-primary: var(--sidebar-primary);
-    --color-sidebar-foreground: var(--sidebar-foreground);
-    --color-sidebar: var(--sidebar);
-    --color-chart-5: var(--chart-5);
-    --color-chart-4: var(--chart-4);
-    --color-chart-3: var(--chart-3);
-    --color-chart-2: var(--chart-2);
-    --color-chart-1: var(--chart-1);
-    --color-ring: var(--ring);
-    --color-input: var(--input);
-    --color-border: var(--border);
-    --color-destructive: var(--destructive);
-    --color-accent-foreground: var(--accent-foreground);
-    --color-accent: var(--accent);
-    --color-muted-foreground: var(--muted-foreground);
-    --color-muted: var(--muted);
-    --color-secondary-foreground: var(--secondary-foreground);
-    --color-secondary: var(--secondary);
-    --color-primary-foreground: var(--primary-foreground);
-    --color-primary: var(--primary);
-    --color-popover-foreground: var(--popover-foreground);
-    --color-popover: var(--popover);
-    --color-card-foreground: var(--card-foreground);
-    --color-card: var(--card);
-    --radius-sm: calc(var(--radius) - 4px);
-    --radius-md: calc(var(--radius) - 2px);
-    --radius-lg: var(--radius);
-    --radius-xl: calc(var(--radius) + 4px);
+	--color-background: var(--background);
+	--color-foreground: var(--foreground);
+	--font-sans: var(--font-geist-sans);
+	--font-mono: var(--font-geist-mono);
+	--color-sidebar-ring: var(--sidebar-ring);
+	--color-sidebar-border: var(--sidebar-border);
+	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+	--color-sidebar-accent: var(--sidebar-accent);
+	--color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+	--color-sidebar-primary: var(--sidebar-primary);
+	--color-sidebar-foreground: var(--sidebar-foreground);
+	--color-sidebar: var(--sidebar);
+	--color-chart-5: var(--chart-5);
+	--color-chart-4: var(--chart-4);
+	--color-chart-3: var(--chart-3);
+	--color-chart-2: var(--chart-2);
+	--color-chart-1: var(--chart-1);
+	--color-ring: var(--ring);
+	--color-input: var(--input);
+	--color-border: var(--border);
+	--color-destructive: var(--destructive);
+	--color-accent-foreground: var(--accent-foreground);
+	--color-accent: var(--accent);
+	--color-muted-foreground: var(--muted-foreground);
+	--color-muted: var(--muted);
+	--color-secondary-foreground: var(--secondary-foreground);
+	--color-secondary: var(--secondary);
+	--color-primary-foreground: var(--primary-foreground);
+	--color-primary: var(--primary);
+	--color-popover-foreground: var(--popover-foreground);
+	--color-popover: var(--popover);
+	--color-card-foreground: var(--card-foreground);
+	--color-card: var(--card);
+	--radius-sm: calc(var(--radius) - 4px);
+	--radius-md: calc(var(--radius) - 2px);
+	--radius-lg: var(--radius);
+	--radius-xl: calc(var(--radius) + 4px);
 }
 
 :root {
-    --radius: 0.625rem;
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.145 0 0);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.145 0 0);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.145 0 0);
-    --primary: oklch(0.205 0 0);
-    --primary-foreground: oklch(0.985 0 0);
-    --secondary: oklch(0.97 0 0);
-    --secondary-foreground: oklch(0.205 0 0);
-    --muted: oklch(0.97 0 0);
-    --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.97 0 0);
-    --accent-foreground: oklch(0.205 0 0);
-    --destructive: oklch(0.577 0.245 27.325);
-    --border: oklch(0.922 0 0);
-    --input: oklch(0.922 0 0);
-    --ring: oklch(0.708 0 0);
-    --chart-1: oklch(0.646 0.222 41.116);
-    --chart-2: oklch(0.6 0.118 184.704);
-    --chart-3: oklch(0.398 0.07 227.392);
-    --chart-4: oklch(0.828 0.189 84.429);
-    --chart-5: oklch(0.769 0.188 70.08);
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.145 0 0);
-    --sidebar-primary: oklch(0.205 0 0);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.97 0 0);
-    --sidebar-accent-foreground: oklch(0.205 0 0);
-    --sidebar-border: oklch(0.922 0 0);
-    --sidebar-ring: oklch(0.708 0 0);
+	--radius: 0.625rem;
+	--background: oklch(1 0 0);
+	--foreground: oklch(0.145 0 0);
+	--card: oklch(1 0 0);
+	--card-foreground: oklch(0.145 0 0);
+	--popover: oklch(1 0 0);
+	--popover-foreground: oklch(0.145 0 0);
+	--primary: oklch(0.205 0 0);
+	--primary-foreground: oklch(0.985 0 0);
+	--secondary: oklch(0.97 0 0);
+	--secondary-foreground: oklch(0.205 0 0);
+	--muted: oklch(0.97 0 0);
+	--muted-foreground: oklch(0.556 0 0);
+	--accent: oklch(0.97 0 0);
+	--accent-foreground: oklch(0.205 0 0);
+	--destructive: oklch(0.577 0.245 27.325);
+	--border: oklch(0.922 0 0);
+	--input: oklch(0.922 0 0);
+	--ring: oklch(0.708 0 0);
+	--chart-1: oklch(0.646 0.222 41.116);
+	--chart-2: oklch(0.6 0.118 184.704);
+	--chart-3: oklch(0.398 0.07 227.392);
+	--chart-4: oklch(0.828 0.189 84.429);
+	--chart-5: oklch(0.769 0.188 70.08);
+	--sidebar: oklch(0.985 0 0);
+	--sidebar-foreground: oklch(0.145 0 0);
+	--sidebar-primary: oklch(0.205 0 0);
+	--sidebar-primary-foreground: oklch(0.985 0 0);
+	--sidebar-accent: oklch(0.97 0 0);
+	--sidebar-accent-foreground: oklch(0.205 0 0);
+	--sidebar-border: oklch(0.922 0 0);
+	--sidebar-ring: oklch(0.708 0 0);
 }
 
 .dark {
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.205 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.922 0 0);
-    --primary-foreground: oklch(0.205 0 0);
-    --secondary: oklch(0.269 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.269 0 0);
-    --accent-foreground: oklch(0.985 0 0);
-    --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.556 0 0);
-    --chart-1: oklch(0.488 0.243 264.376);
-    --chart-2: oklch(0.696 0.17 162.48);
-    --chart-3: oklch(0.769 0.188 70.08);
-    --chart-4: oklch(0.627 0.265 303.9);
-    --chart-5: oklch(0.645 0.246 16.439);
-    --sidebar: oklch(0.205 0 0);
-    --sidebar-foreground: oklch(0.985 0 0);
-    --sidebar-primary: oklch(0.488 0.243 264.376);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.269 0 0);
-    --sidebar-accent-foreground: oklch(0.985 0 0);
-    --sidebar-border: oklch(1 0 0 / 10%);
-    --sidebar-ring: oklch(0.556 0 0);
+	--background: oklch(0.145 0 0);
+	--foreground: oklch(0.985 0 0);
+	--card: oklch(0.205 0 0);
+	--card-foreground: oklch(0.985 0 0);
+	--popover: oklch(0.205 0 0);
+	--popover-foreground: oklch(0.985 0 0);
+	--primary: oklch(0.922 0 0);
+	--primary-foreground: oklch(0.205 0 0);
+	--secondary: oklch(0.269 0 0);
+	--secondary-foreground: oklch(0.985 0 0);
+	--muted: oklch(0.269 0 0);
+	--muted-foreground: oklch(0.708 0 0);
+	--accent: oklch(0.269 0 0);
+	--accent-foreground: oklch(0.985 0 0);
+	--destructive: oklch(0.704 0.191 22.216);
+	--border: oklch(1 0 0 / 10%);
+	--input: oklch(1 0 0 / 15%);
+	--ring: oklch(0.556 0 0);
+	--chart-1: oklch(0.488 0.243 264.376);
+	--chart-2: oklch(0.696 0.17 162.48);
+	--chart-3: oklch(0.769 0.188 70.08);
+	--chart-4: oklch(0.627 0.265 303.9);
+	--chart-5: oklch(0.645 0.246 16.439);
+	--sidebar: oklch(0.205 0 0);
+	--sidebar-foreground: oklch(0.985 0 0);
+	--sidebar-primary: oklch(0.488 0.243 264.376);
+	--sidebar-primary-foreground: oklch(0.985 0 0);
+	--sidebar-accent: oklch(0.269 0 0);
+	--sidebar-accent-foreground: oklch(0.985 0 0);
+	--sidebar-border: oklch(1 0 0 / 10%);
+	--sidebar-ring: oklch(0.556 0 0);
 }
 
 @layer base {
-    * {
-        @apply border-border outline-ring/50;
-    }
+	* {
+		@apply border-border outline-ring/50;
+	}
+	body {
+		@apply bg-background text-foreground;
+	}
 
-    body {
-        @apply bg-background text-foreground;
-    }
+	:root {
+		--sidebar-background: 0 0% 98%;
+		--sidebar-foreground: 240 5.3% 26.1%;
+		--sidebar-primary: 240 5.9% 10%;
+		--sidebar-primary-foreground: 0 0% 98%;
+		--sidebar-accent: 240 4.8% 95.9%;
+		--sidebar-accent-foreground: 240 5.9% 10%;
+		--sidebar-border: 220 13% 91%;
+		--sidebar-ring: 217.2 91.2% 59.8%;
+	}
 
-    :root {
-        --sidebar-background: 0 0% 98%;
-        --sidebar-foreground: 240 5.3% 26.1%;
-        --sidebar-primary: 240 5.9% 10%;
-        --sidebar-primary-foreground: 0 0% 98%;
-        --sidebar-accent: 240 4.8% 95.9%;
-        --sidebar-accent-foreground: 240 5.9% 10%;
-        --sidebar-border: 220 13% 91%;
-        --sidebar-ring: 217.2 91.2% 59.8%;
-    }
-
-    .dark {
-        --sidebar-background: 240 5.9% 10%;
-        --sidebar-foreground: 240 4.8% 95.9%;
-        --sidebar-primary: 224.3 76.3% 48%;
-        --sidebar-primary-foreground: 0 0% 100%;
-        --sidebar-accent: 240 3.7% 15.9%;
-        --sidebar-accent-foreground: 240 4.8% 95.9%;
-        --sidebar-border: 240 3.7% 15.9%;
-        --sidebar-ring: 217.2 91.2% 59.8%;
-    }
+	.dark {
+		--sidebar-background: 240 5.9% 10%;
+		--sidebar-foreground: 240 4.8% 95.9%;
+		--sidebar-primary: 224.3 76.3% 48%;
+		--sidebar-primary-foreground: 0 0% 100%;
+		--sidebar-accent: 240 3.7% 15.9%;
+		--sidebar-accent-foreground: 240 4.8% 95.9%;
+		--sidebar-border: 240 3.7% 15.9%;
+		--sidebar-ring: 217.2 91.2% 59.8%;
+	}
 }
 
 main {
-    width: 100%;
+	width: 100%;
 }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,39 +1,32 @@
-import type {Metadata} from "next";
-import {Inter} from "next/font/google";
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
 import "./globals.css";
-import {AuthProvider} from "@/components/contexts/auth-context";
+import { AuthProvider } from "@/components/contexts/auth-context";
 import NavBar from "@/components/navbar/navbar";
-import {ThemeProvider} from "@/components/themes/theme-provider";
+import { ThemeProvider } from "@/components/themes/theme-provider";
 import Starfield from "react-starfield";
 
-const inter = Inter({subsets: ['latin']})
+const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
 	title: "Tier Rating",
 	description: "Rate your media content in a tier list",
 };
 
-export default function Layout({children}: { children: React.ReactNode }) {
+export default function Layout({ children }: { children: React.ReactNode }) {
 	return (
 		<html lang="en" suppressHydrationWarning>
-		<body className={inter.className}>
-		<ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-			<Starfield
-				starCount={500}
-				starColor={[255, 255, 255]}
-				speedFactor={0.05}
-				backgroundColor="black"
-			/>
-			<AuthProvider>
-				<div className="min-h-screen flex flex-col">
-					<NavBar/>
-					<main className="flex-grow pt-24 z-20">
-						{children}
-					</main>
-				</div>
-			</AuthProvider>
-		</ThemeProvider>
-		</body>
+			<body className={inter.className}>
+				<ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+					<Starfield starCount={500} starColor={[255, 255, 255]} speedFactor={0.05} backgroundColor="black" />
+					<AuthProvider>
+						<div className="min-h-screen flex flex-col">
+							<NavBar />
+							<main className="flex-grow pt-24 z-20">{children}</main>
+						</div>
+					</AuthProvider>
+				</ThemeProvider>
+			</body>
 		</html>
-	)
+	);
 }

--- a/web/app/login/login-form.tsx
+++ b/web/app/login/login-form.tsx
@@ -1,49 +1,45 @@
-"use client"
+"use client";
 
-import Link from "next/link"
-import {useState} from "react"
-import {Button} from "@/components/ui/button"
-import {Input} from "@/components/ui/input"
-import {Label} from "@/components/ui/label"
-import {EyeIcon, EyeOffIcon} from "lucide-react"
-import {useAuth} from "@/components/contexts/auth-context";
-import {requestLogin} from "@/components/api/user-api";
+import Link from "next/link";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { EyeIcon, EyeOffIcon } from "lucide-react";
+import { useAuth } from "@/components/contexts/auth-context";
+import { requestLogin } from "@/components/api/user-api";
 
 export function InputForm() {
-	const [showPassword, setShowPassword] = useState(false)
-	const [isLoading, setIsLoading] = useState(false)
-	const [username, setUsername] = useState("")
-	const [password, setPassword] = useState("")
-	const [errorMessage, setErrorMessage] = useState("")
-	const {login} = useAuth();
+	const [showPassword, setShowPassword] = useState(false);
+	const [isLoading, setIsLoading] = useState(false);
+	const [username, setUsername] = useState("");
+	const [password, setPassword] = useState("");
+	const [errorMessage, setErrorMessage] = useState("");
+	const { login } = useAuth();
 
 	const handleSubmit = async (e: React.FormEvent) => {
-		e.preventDefault()
-		setIsLoading(true)
-		setErrorMessage("")
+		e.preventDefault();
+		setIsLoading(true);
+		setErrorMessage("");
 
 		requestLogin(username, password)
-			.then(response => {
+			.then((response) => {
 				if (response.status === 401) throw new Error("Invalid credentials");
 				if (response.error) throw new Error(response.error);
-				if (!response.data) throw new Error("Faulty response")
+				if (!response.data) throw new Error("Faulty response");
 				login(response.data.token);
 			})
-			.catch(error => {
-				setErrorMessage(error instanceof Error ? error.message : 'Login failed. Please try again.')
+			.catch((error) => {
+				setErrorMessage(error instanceof Error ? error.message : "Login failed. Please try again.");
 			})
 			.finally(() => {
 				setTimeout(() => setIsLoading(false), 1000);
 			});
-	}
+	};
 
 	return (
 		<div>
-			{errorMessage && (
-				<div className="bg-destructive/15 text-destructive text-sm p-3 rounded-md mb-4">
-					{errorMessage}
-				</div>
-			)}
+			{errorMessage && <div className="bg-destructive/15 text-destructive text-sm p-3 rounded-md mb-4">{errorMessage}</div>}
 			<form onSubmit={handleSubmit} className="space-y-4">
 				<div className="space-y-2">
 					<Label htmlFor="username">Username</Label>
@@ -78,29 +74,20 @@ export function InputForm() {
 							className="absolute right-0 top-0 h-full px-3 py-2 text-muted-foreground hover:text-foreground"
 							onClick={() => setShowPassword(!showPassword)}
 						>
-							{showPassword ? (<EyeOffIcon className="h-4 w-4"/>) : (
-								<EyeIcon className="h-4 w-4"/>)}
-							<span
-								className="sr-only">{showPassword ? "Hide password" : "Show password"}</span>
+							{showPassword ? <EyeOffIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}
+							<span className="sr-only">{showPassword ? "Hide password" : "Show password"}</span>
 						</Button>
 					</div>
 					<div className="flex items-center justify-end">
-						<Link
-							href="/forgot-password"
-							className="text-xs text-primary hover:underline"
-						>
+						<Link href="/forgot-password" className="text-xs text-primary hover:underline">
 							Forgot password?
 						</Link>
 					</div>
 				</div>
-				<Button
-					type="submit"
-					className="w-full"
-					disabled={isLoading}
-				>
+				<Button type="submit" className="w-full" disabled={isLoading}>
 					{isLoading ? "Signing in..." : "Sign in"}
 				</Button>
 			</form>
 		</div>
-	)
+	);
 }

--- a/web/app/login/login-success-message.tsx
+++ b/web/app/login/login-success-message.tsx
@@ -1,10 +1,10 @@
-"use client"
+"use client";
 
-import {useSearchParams} from "next/navigation";
+import { useSearchParams } from "next/navigation";
 
 export function SuccessMessage() {
-	const searchParams = useSearchParams()
-	const signupSuccess = searchParams.get('signup') === 'success'
+	const searchParams = useSearchParams();
+	const signupSuccess = searchParams.get("signup") === "success";
 
 	return (
 		<div>
@@ -14,5 +14,5 @@ export function SuccessMessage() {
 				</div>
 			)}
 		</div>
-	)
+	);
 }

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,35 +1,26 @@
-import Link from "next/link"
-import {Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle} from "@/components/ui/card"
-import {AnonymousAllowedRoute} from "@/components/contexts/route-accessibility";
-import {InputForm} from "@/app/login/login-form";
-import {SuccessMessage} from "@/app/login/login-success-message";
-import {cn} from "@/lib/utils";
+import Link from "next/link";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { AnonymousAllowedRoute } from "@/components/contexts/route-accessibility";
+import { InputForm } from "@/app/login/login-form";
+import { SuccessMessage } from "@/app/login/login-success-message";
+import { cn } from "@/lib/utils";
 
 export default function LoginPage() {
-
 	return (
 		<AnonymousAllowedRoute>
 			<div className="flex min-h-screen -mt-24 items-center justify-center px-4">
-				<Card className={cn(
-					"w-full max-w-md z-50",
-					"bg-card/60 backdrop-blur-sm border border-border/100 shadow-lg",
-				)}>
+				<Card className={cn("w-full max-w-md z-50", "bg-card/60 backdrop-blur-sm border border-border/100 shadow-lg")}>
 					<CardHeader className="space-y-1">
 						<CardTitle className="text-2xl font-bold">Login</CardTitle>
-						<CardDescription>
-							Enter your credentials to access your account
-						</CardDescription>
+						<CardDescription>Enter your credentials to access your account</CardDescription>
 					</CardHeader>
 					<CardContent>
-						<SuccessMessage/>
-						<InputForm/>
+						<SuccessMessage />
+						<InputForm />
 					</CardContent>
 					<CardFooter className="flex flex-col space-y-4 pt-4">
 						<div className="text-center text-sm">
-							<Link
-								href="/signup"
-								className="text-primary hover:underline"
-							>
+							<Link href="/signup" className="text-primary hover:underline">
 								Don&apos;t have an account? Sign up
 							</Link>
 						</div>
@@ -37,5 +28,5 @@ export default function LoginPage() {
 				</Card>
 			</div>
 		</AnonymousAllowedRoute>
-	)
+	);
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,5 +1,5 @@
-import {redirect} from 'next/navigation'
+import { redirect } from "next/navigation";
 
 export default function Home() {
-	redirect('/login')
+	redirect("/login");
 }

--- a/web/app/settings/account-modification.tsx
+++ b/web/app/settings/account-modification.tsx
@@ -1,67 +1,56 @@
-"use client"
+"use client";
 
-import {Popover, PopoverContent, PopoverTrigger} from "@/components/ui/popover";
-import {Button} from "@/components/ui/button";
-import {useAuth} from "@/components/contexts/auth-context";
-import {deleteAccount} from "@/components/api/user-api";
-import {useState} from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/components/contexts/auth-context";
+import { deleteAccount } from "@/components/api/user-api";
+import { useState } from "react";
 
 export default function AccountModification() {
-	const {user, token, logout} = useAuth();
+	const { user, token, logout } = useAuth();
 	const [errorMessage, setErrorMessage] = useState("");
 	const [isDeleting, setIsDeleting] = useState(false);
 
 	const submitDeletion = () => {
 		setIsDeleting(true);
 		deleteAccount(user, token)
-			.then(response => {
+			.then((response) => {
 				if (response.status === 401 || response.status === 403) {
-					logout()
+					logout();
 					throw new Error("Session expired or unauthorized");
 				}
-				if (response.status != 200) throw new Error(response.data ? response.data.message : `API error: ${response.status}`)
+				if (response.status != 200) throw new Error(response.data ? response.data.message : `API error: ${response.status}`);
 
 				setTimeout(() => logout(), 1000);
 				setErrorMessage("");
 			})
-			.catch(error => {
+			.catch((error) => {
 				setErrorMessage(error.message);
 			})
 			.finally(() => {
 				setIsDeleting(false);
-			})
-	}
+			});
+	};
 
 	return (
 		<div className={"w-full"}>
 			<Popover>
 				<PopoverTrigger asChild>
-					<Button
-						className={"w-full"}
-						variant={"destructive"}
-					>
+					<Button className={"w-full"} variant={"destructive"}>
 						Delete Account
 					</Button>
 				</PopoverTrigger>
 				<PopoverContent>
 					<div className={"gap-4 w-full"}>
-						<Button
-							className={"w-full"}
-							variant={"destructive"}
-							type={"submit"}
-							disabled={isDeleting}
-							onClick={submitDeletion}
-						>
+						<Button className={"w-full"} variant={"destructive"} type={"submit"} disabled={isDeleting} onClick={submitDeletion}>
 							Are you sure?
 						</Button>
 						{errorMessage && (
-							<div className="bg-destructive/15 text-destructive text-sm p-2 rounded-md mt-4">
-								{errorMessage}
-							</div>
+							<div className="bg-destructive/15 text-destructive text-sm p-2 rounded-md mt-4">{errorMessage}</div>
 						)}
 					</div>
 				</PopoverContent>
 			</Popover>
 		</div>
-	)
+	);
 }

--- a/web/app/settings/change-password.tsx
+++ b/web/app/settings/change-password.tsx
@@ -1,34 +1,34 @@
-"use client"
+"use client";
 
-import {z} from "zod"
-import {useState} from "react";
-import {useRouter} from "next/navigation";
-import {useForm} from "react-hook-form";
-import {zodResolver} from "@hookform/resolvers/zod";
-import {changePassword} from "@/components/api/user-api";
-import {useAuth} from "@/components/contexts/auth-context";
-import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from "@/components/ui/form";
-import {Input} from "@/components/ui/input";
-import {Button} from "@/components/ui/button";
-import {EyeIcon, EyeOffIcon} from "lucide-react";
+import { z } from "zod";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { changePassword } from "@/components/api/user-api";
+import { useAuth } from "@/components/contexts/auth-context";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { EyeIcon, EyeOffIcon } from "lucide-react";
 
-const FormSchema = z.object({
-	old: z.string(),
-	new: z.string().min(8).max(30),
-	confirmNew: z.string().min(8).max(30)
-}).refine((data) => data.new === data.confirmNew, {
-	message: "Passwords don't match",
-	path: ['confirmPassword']
-});
+const FormSchema = z
+	.object({
+		old: z.string(),
+		new: z.string().min(8).max(30),
+		confirmNew: z.string().min(8).max(30),
+	})
+	.refine((data) => data.new === data.confirmNew, {
+		message: "Passwords don't match",
+		path: ["confirmPassword"],
+	});
 
 export default function ChangePassword() {
 	const [showOld, setShowOld] = useState(false);
 	const [showNew, setShowNew] = useState(false);
 	const [showConfirmNew, setShowConfirmNew] = useState(false);
-	const [isSubmitLoading, setSubmitLoading] = useState(false)
+	const [isSubmitLoading, setSubmitLoading] = useState(false);
 	const [errorMessage, setErrorMessage] = useState("");
-	const {user, token, logout} = useAuth();
-	const router = useRouter();
+	const { user, token, logout } = useAuth();
 
 	const form = useForm<z.infer<typeof FormSchema>>({
 		resolver: zodResolver(FormSchema),
@@ -37,42 +37,38 @@ export default function ChangePassword() {
 			new: "",
 			confirmNew: "",
 		},
-	})
+	});
 
 	function onSubmit(data: z.infer<typeof FormSchema>) {
 		setSubmitLoading(true);
 		changePassword(data.old, data.new, user, token)
-			.then(response => {
+			.then((response) => {
 				if (response.status === 401 || response.status === 403) {
-					logout()
+					logout();
 					throw new Error("Session expired or unauthorized");
 				}
-				if (response.status != 200) throw new Error(response.data ? response.data.message : `API error: ${response.status}`)
+				if (response.status != 200) throw new Error(response.data ? response.data.message : `API error: ${response.status}`);
 
 				setTimeout(() => logout(), 1000);
 				setErrorMessage("");
 			})
-			.catch(error => {
+			.catch((error) => {
 				setErrorMessage(error.message);
 			})
 			.finally(() => {
 				setSubmitLoading(false);
-			})
+			});
 	}
 
 	return (
 		<div className={"w-full"}>
-			{errorMessage && (
-				<div className="bg-destructive/15 text-destructive text-sm p-3 rounded-md mb-4">
-					{errorMessage}
-				</div>
-			)}
+			{errorMessage && <div className="bg-destructive/15 text-destructive text-sm p-3 rounded-md mb-4">{errorMessage}</div>}
 			<Form {...form}>
 				<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
 					<FormField
 						control={form.control}
 						name="old"
-						render={({field}) => (
+						render={({ field }) => (
 							<FormItem>
 								<FormLabel>Old password</FormLabel>
 								<FormControl>
@@ -85,25 +81,19 @@ export default function ChangePassword() {
 											className="absolute right-0 top-0 h-full px-3 py-2 text-muted-foreground hover:text-foreground"
 											onClick={() => setShowOld(!showOld)}
 										>
-											{showOld ? (
-												<EyeOffIcon className="h-4 w-4"/>
-											) : (
-												<EyeIcon className="h-4 w-4"/>
-											)}
-											<span className="sr-only">
-                                                {showOld ? "Hide password" : "Show password"}
-                                            </span>
+											{showOld ? <EyeOffIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}
+											<span className="sr-only">{showOld ? "Hide password" : "Show password"}</span>
 										</Button>
 									</div>
 								</FormControl>
-								<FormMessage/>
+								<FormMessage />
 							</FormItem>
 						)}
 					/>
 					<FormField
 						control={form.control}
 						name="new"
-						render={({field}) => (
+						render={({ field }) => (
 							<FormItem>
 								<FormLabel>New password</FormLabel>
 								<FormControl>
@@ -116,25 +106,19 @@ export default function ChangePassword() {
 											className="absolute right-0 top-0 h-full px-3 py-2 text-muted-foreground hover:text-foreground"
 											onClick={() => setShowNew(!showNew)}
 										>
-											{showNew ? (
-												<EyeOffIcon className="h-4 w-4"/>
-											) : (
-												<EyeIcon className="h-4 w-4"/>
-											)}
-											<span className="sr-only">
-                                                {showNew ? "Hide password" : "Show password"}
-                                            </span>
+											{showNew ? <EyeOffIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}
+											<span className="sr-only">{showNew ? "Hide password" : "Show password"}</span>
 										</Button>
 									</div>
 								</FormControl>
-								<FormMessage/>
+								<FormMessage />
 							</FormItem>
 						)}
 					/>
 					<FormField
 						control={form.control}
 						name="confirmNew"
-						render={({field}) => (
+						render={({ field }) => (
 							<FormItem>
 								<FormLabel>Confirm new password</FormLabel>
 								<FormControl>
@@ -147,30 +131,20 @@ export default function ChangePassword() {
 											className="absolute right-0 top-0 h-full px-3 py-2 text-muted-foreground hover:text-foreground"
 											onClick={() => setShowConfirmNew(!showConfirmNew)}
 										>
-											{showConfirmNew ? (
-												<EyeOffIcon className="h-4 w-4"/>
-											) : (
-												<EyeIcon className="h-4 w-4"/>
-											)}
-											<span className="sr-only">
-                                                {showConfirmNew ? "Hide password" : "Show password"}
-                                            </span>
+											{showConfirmNew ? <EyeOffIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}
+											<span className="sr-only">{showConfirmNew ? "Hide password" : "Show password"}</span>
 										</Button>
 									</div>
 								</FormControl>
-								<FormMessage/>
+								<FormMessage />
 							</FormItem>
 						)}
 					/>
-					<Button
-						type="submit"
-						className="w-full"
-						disabled={isSubmitLoading}
-					>
+					<Button type="submit" className="w-full" disabled={isSubmitLoading}>
 						{isSubmitLoading ? "Changing password..." : "Change password"}
 					</Button>
 				</form>
 			</Form>
 		</div>
-	)
+	);
 }

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -1,5 +1,5 @@
 import ChangePassword from "@/app/settings/change-password";
-import {Card, CardContent, CardHeader} from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import AccountModification from "@/app/settings/account-modification";
 import ThirdPartyConfig from "@/app/settings/third-party-config";
 
@@ -7,29 +7,23 @@ export default function Settings() {
 	return (
 		<div className={"flex flex-wrap items-start justify-center gap-4 w-full min-w-4/5 pr-4 pl-4"}>
 			<Card className={"max-w-120 w-full"}>
-				<CardHeader>
-					Connect Third-Party Service
-				</CardHeader>
+				<CardHeader>Connect Third-Party Service</CardHeader>
 				<CardContent>
-					<ThirdPartyConfig/>
+					<ThirdPartyConfig />
 				</CardContent>
 			</Card>
 			<Card className={"max-w-120 w-full"}>
-				<CardHeader>
-					Change Password
-				</CardHeader>
+				<CardHeader>Change Password</CardHeader>
 				<CardContent>
-					<ChangePassword/>
+					<ChangePassword />
 				</CardContent>
 			</Card>
 			<Card className={"max-w-120 w-full"}>
+				<CardHeader>Account Deletion</CardHeader>
 				<CardHeader>
-					Account Deletion
-				</CardHeader>
-				<CardHeader>
-					<AccountModification/>
+					<AccountModification />
 				</CardHeader>
 			</Card>
 		</div>
-	)
+	);
 }

--- a/web/app/settings/third-party-config.tsx
+++ b/web/app/settings/third-party-config.tsx
@@ -1,18 +1,18 @@
-"use client"
+"use client";
 
-import {useAuth} from "@/components/contexts/auth-context";
-import {useEffect, useState} from "react";
+import { useAuth } from "@/components/contexts/auth-context";
+import { useEffect, useState } from "react";
 
-import {fetchUser, removeConnection} from "@/components/api/user-api";
-import {fetchConfiguredServices} from "@/components/api/config-api";
+import { fetchUser, removeConnection } from "@/components/api/user-api";
+import { fetchConfiguredServices } from "@/components/api/config-api";
 import LoadingPage from "@/components/loading-skeletons/loading-page";
 import ThirdPartyLoginButton from "@/app/settings/third-party-login-button";
-import {UserResponse} from "@/components/model/response-types";
+import { UserResponse } from "@/components/model/response-types";
 import ThirdPartyConnection from "@/app/settings/third-party-connection";
-import {router} from "next/client";
+import { router } from "next/client";
 
 export default function ThirdPartyConfig() {
-	const {user, token, logout, isLoading, isAuthenticated} = useAuth();
+	const { user, token, logout, isLoading, isAuthenticated } = useAuth();
 
 	const [isRemovingService, setIsRemovingService] = useState(false);
 	const [userResponse, setUserResponse] = useState<UserResponse>();
@@ -21,27 +21,27 @@ export default function ThirdPartyConfig() {
 	const removeService = (service: string) => {
 		setIsRemovingService(true);
 		removeConnection(service, user, token)
-			.then(response => {
+			.then((response) => {
 				if (response.status === 401 || response.status === 403) {
-					logout()
+					logout();
 					throw new Error("Session expired or unauthorized");
 				}
-				if (response.status != 200) throw new Error(response.data ? response.data.message : `API error: ${response.status}`)
+				if (response.status != 200) throw new Error(response.data ? response.data.message : `API error: ${response.status}`);
 				console.debug(`${service} connection removed`);
 				router.reload();
 			})
-			.catch(error => {
+			.catch((error) => {
 				console.error(error.message);
 			})
 			.finally(() => {
 				setIsRemovingService(false);
-			})
-	}
+			});
+	};
 
 	useEffect(() => {
 		if (!isLoading && isAuthenticated && user) {
 			fetchUser(token, user)
-				.then(response => {
+				.then((response) => {
 					if (response.status === 401 || response.status === 403) {
 						logout();
 						throw new Error("Session expired");
@@ -51,14 +51,14 @@ export default function ThirdPartyConfig() {
 					if (!response.data) throw new Error("Faulty response");
 					setUserResponse(response.data);
 				})
-				.catch((error) => console.error(error))
+				.catch((error) => console.error(error));
 		}
 	}, [isLoading, isAuthenticated, user, token, logout]);
 
 	useEffect(() => {
 		if (!isLoading && isAuthenticated) {
 			fetchConfiguredServices(token)
-				.then(response => {
+				.then((response) => {
 					if (response.status === 401 || response.status === 403) {
 						logout();
 						throw new Error("Session expired");
@@ -68,51 +68,65 @@ export default function ThirdPartyConfig() {
 					if (!response.data) throw new Error("Faulty response");
 					setConfiguredServices(response.data);
 				})
-				.catch((error) => console.error(error))
+				.catch((error) => console.error(error));
 		}
-	}, [isAuthenticated, isLoading, logout, token])
+	}, [isAuthenticated, isLoading, logout, token]);
 
-	if (!userResponse || !configuredServices || !user) return <LoadingPage/>
+	if (!userResponse || !configuredServices || !user) return <LoadingPage />;
 
 	return (
 		<div className={"w-full grid gap-4"}>
-			{
-				userResponse.connectedServices.length != configuredServices.length
-				&& <div className="grid columns-1 gap-2">
-					{
-						configuredServices.includes('anilist')
-						&& !userResponse.connectedServices.includes('ANILIST')
-						&& <ThirdPartyLoginButton title={"Connect AniList"} path={"/auth/anilist"} service="anilist"/>
-					}
-					{
-						configuredServices.includes('trakt')
-						&& !userResponse.connectedServices.includes('TRAKT')
-						&& <ThirdPartyLoginButton title={"Connect Trakt"} path={"/auth/trakt"} service="trakt"/>
-					}
-                </div>
-			}
-			{
-				userResponse.connectedServices.length > 0
-				&& <div className="grid columns-1 gap-2">
-					{
-						userResponse.connectedServices.includes('ANILIST')
-						&& <ThirdPartyConnection service={{id: "anilist", title: "Anilist"}}
-                                                 types={[{id: "anime", title: "Anime"}, {id: "manga", title: "Manga"}]}
-                                                 removeConnection={removeService} isRemovingService={isRemovingService}
-                                                 username={user} token={token} logout={logout}/>
-					}
-					{
-						userResponse.connectedServices.includes('TRAKT')
-						&& <ThirdPartyConnection service={{id: "trakt", title: "Trakt"}}
-                                                 types={[{id: "movies", title: "Movies"}, {
-													 id: "tvshows",
-													 title: "TV Shows"
-												 }, {id: "tvshows-seasons", title: "TV Shows - Seasons"}]}
-                                                 removeConnection={removeService} isRemovingService={isRemovingService}
-                                                 username={user} token={token} logout={logout}/>
-					}
-                </div>
-			}
+			<div className="grid columns-1 gap-2">
+				{configuredServices.includes("anilist") && !userResponse.connectedServices.includes("ANILIST") && (
+					<ThirdPartyLoginButton
+						index={0}
+						title={"Connect AniList"}
+						path={"/auth/anilist"}
+						color={"bg-blue-600 hover:bg-blue-700"}
+						service="anilist"
+					/>
+				)}
+				{configuredServices.includes("trakt") && !userResponse.connectedServices.includes("TRAKT") && (
+					<ThirdPartyLoginButton
+						index={1}
+						title={"Connect Trakt"}
+						path={"/auth/trakt"}
+						color={"bg-red-600 hover:bg-red-700"}
+						service="trakt"
+					/>
+				)}
+			</div>
+			<div className="grid columns-1 gap-2">
+				{userResponse.connectedServices.includes("ANILIST") && (
+					<ThirdPartyConnection
+						service={{ id: "anilist", title: "Anilist" }}
+						types={[
+							{ id: "anime", title: "Anime" },
+							{ id: "manga", title: "Manga" },
+						]}
+						removeConnection={removeService}
+						isRemovingService={isRemovingService}
+						username={user}
+						token={token}
+						logout={logout}
+					/>
+				)}
+				{userResponse.connectedServices.includes("TRAKT") && (
+					<ThirdPartyConnection
+						service={{ id: "trakt", title: "Trakt" }}
+						types={[
+							{ id: "movies", title: "Movies" },
+							{ id: "tvshows", title: "TV Shows" },
+							{ id: "tvshows-seasons", title: "TV Shows - Seasons" },
+						]}
+						removeConnection={removeService}
+						isRemovingService={isRemovingService}
+						username={user}
+						token={token}
+						logout={logout}
+					/>
+				)}
+			</div>
 		</div>
-	)
+	);
 }

--- a/web/app/settings/third-party-connected-button.tsx
+++ b/web/app/settings/third-party-connected-button.tsx
@@ -1,10 +1,10 @@
-import {Button} from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import TierConfigModal from "@/components/tiers/tier-config-modal";
-import {Tier} from "@/components/model/types";
+import { Tier } from "@/components/model/types";
 import React from "react";
-import {updateTiers} from "@/components/api/tier-api";
+import { updateTiers } from "@/components/api/tier-api";
 import Link from "next/link";
-import {ButtonGroup} from "@/components/ui/button-group";
+import { ButtonGroup } from "@/components/ui/button-group";
 
 function getDecimals(service: string): string {
 	if (service === "anilist") return "0.01";
@@ -12,34 +12,38 @@ function getDecimals(service: string): string {
 	return "1.00";
 }
 
-export default function ThirdPartyConnectedButton({service, type, title, username, token, logout}: {
-	service: string,
-	type: string,
-	title: string,
-	username: string,
-	token: string | null,
-	logout: () => void
+export default function ThirdPartyConnectedButton({
+	service,
+	type,
+	title,
+	username,
+	token,
+	logout,
+}: {
+	service: string;
+	type: string;
+	title: string;
+	username: string;
+	token: string | null;
+	logout: () => void;
 }) {
 	const saveTiers = (type: string, tiers: Tier[]) => {
-		updateTiers(token, username, service, type, tiers)
-			.then(response => {
-				if (response.status === 401 || response.status === 403) {
-					logout();
-					throw new Error("Session expired");
-				}
+		updateTiers(token, username, service, type, tiers).then((response) => {
+			if (response.status === 401 || response.status === 403) {
+				logout();
+				throw new Error("Session expired");
+			}
 
-				if (response.status === 404) throw new Error("User not found or user doesn't have requested service connected");
-				if (response.error) throw new Error(`API error: ${response.status}`);
-			});
-	}
+			if (response.status === 404) throw new Error("User not found or user doesn't have requested service connected");
+			if (response.error) throw new Error(`API error: ${response.status}`);
+		});
+	};
 
 	return (
 		<ButtonGroup className={"w-full flex"}>
 			<Button variant="outline" className={"grow"}>
 				<Link href={`/user/${username}/${service}/${type}`} className="w-full">
-					<div className="text-center">
-						{title}
-					</div>
+					<div className="text-center">{title}</div>
 				</Link>
 			</Button>
 
@@ -51,5 +55,5 @@ export default function ThirdPartyConnectedButton({service, type, title, usernam
 				decimals={getDecimals(service)}
 			/>
 		</ButtonGroup>
-	)
+	);
 }

--- a/web/app/settings/third-party-connection.tsx
+++ b/web/app/settings/third-party-connection.tsx
@@ -25,8 +25,8 @@ export default function ThirdPartyConnection({
 	logout: () => void;
 }) {
 	return (
-		<Card className={"gap-1"}>
-			<CardHeader className={"h-9"}>
+		<Card className={"gap-1 py-4"}>
+			<CardHeader className={"h-9 px-4"}>
 				<div className={"w-full flex gap-2 items-center"}>
 					<div className="relative size-7">
 						<Image src={`/icons/${service.id}.svg`} alt={`${service.id} icon`} fill={true} />

--- a/web/app/settings/third-party-connection.tsx
+++ b/web/app/settings/third-party-connection.tsx
@@ -1,61 +1,54 @@
-"use client"
+"use client";
 
-import {Card, CardContent, CardHeader} from "@/components/ui/card";
-import {Button} from "@/components/ui/button";
-import {X} from "lucide-react";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
 
 import Image from "next/image";
 import ThirdPartyConnectedButton from "@/app/settings/third-party-connected-button";
 
 export default function ThirdPartyConnection({
-												 service,
-												 types,
-												 removeConnection,
-												 isRemovingService,
-												 username,
-												 token,
-												 logout
-											 }: {
-	service: { id: string, title: string },
-	types: { id: string, title: string }[],
-	removeConnection: (service: string) => void,
-	isRemovingService: boolean,
-	username: string,
-	token: string | null,
-	logout: () => void
+	service,
+	types,
+	removeConnection,
+	isRemovingService,
+	username,
+	token,
+	logout,
+}: {
+	service: { id: string; title: string };
+	types: { id: string; title: string }[];
+	removeConnection: (service: string) => void;
+	isRemovingService: boolean;
+	username: string;
+	token: string | null;
+	logout: () => void;
 }) {
-
 	return (
-		<Card className={"gap-1 py-4"}>
-			<CardHeader className={"h-9 px-4"}>
+		<Card className={"gap-1"}>
+			<CardHeader className={"h-9"}>
 				<div className={"w-full flex gap-2 items-center"}>
 					<div className="relative size-7">
-						<Image
-							src={`/icons/${service.id}.svg`}
-							alt={`${service.id} icon`}
-							fill={true}
-						/>
+						<Image src={`/icons/${service.id}.svg`} alt={`${service.id} icon`} fill={true} />
 					</div>
 					<div className={"w-full font-bold content-center"}>{service.title}</div>
-					<Button
-						type={"submit"}
-						variant={"ghost"}
-						onClick={() => removeConnection(service.id)}
-						disabled={isRemovingService}
-					>
+					<Button type={"submit"} variant={"ghost"} onClick={() => removeConnection(service.id)} disabled={isRemovingService}>
 						<X></X>
 					</Button>
 				</div>
 			</CardHeader>
-			<CardContent className={"grid gap-1 px-4"}>
-				{
-					types.map(entry => (
-						<ThirdPartyConnectedButton key={service.id + '.' + entry.id} service={service.id}
-												   type={entry.id} title={entry.title} username={username} token={token}
-												   logout={logout}/>
-					))
-				}
+			<CardContent className={"grid gap-1"}>
+				{types.map((entry) => (
+					<ThirdPartyConnectedButton
+						service={service.id}
+						type={entry.id}
+						title={entry.title}
+						username={username}
+						token={token}
+						logout={logout}
+					/>
+				))}
 			</CardContent>
 		</Card>
-	)
+	);
 }

--- a/web/app/settings/third-party-login-button.tsx
+++ b/web/app/settings/third-party-login-button.tsx
@@ -1,30 +1,29 @@
 import Link from "next/link";
-import {Button} from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import Image from "next/image";
 import React from "react";
 
-export default function ThirdPartyLoginButton({title, path, service}: {
-	title: string,
-	path: string,
-	service: string
+export default function ThirdPartyLoginButton({
+	index,
+	title,
+	path,
+	color: _color,
+	service,
+}: {
+	index: number;
+	title: string;
+	path: string;
+	color: string;
+	service: string;
 }) {
 	return (
-		<Link href={path} className="block w-full">
-			<Button
-				variant="outline"
-				className={`cursor-pointer w-full rounded-full`}
-			>
+		<Link key={index} href={path} className="block w-full">
+			<Button variant="outline" className={`cursor-pointer w-full rounded-full`}>
 				<div className="relative w-5 h-5 mr-auto">
-					<Image
-						src={`/icons/${service}.svg`}
-						alt={`${service} icon`}
-						fill={true}
-					/>
+					<Image src={`/icons/${service}.svg`} alt={`${service} icon`} fill={true} />
 				</div>
-				<div className="text-center absolute">
-					{title}
-				</div>
+				<div className="text-center absolute">{title}</div>
 			</Button>
 		</Link>
-	)
+	);
 }

--- a/web/app/signup/page.tsx
+++ b/web/app/signup/page.tsx
@@ -1,30 +1,24 @@
-import Link from "next/link"
+import Link from "next/link";
 
-import {Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle} from "@/components/ui/card"
-import {SignUpForm} from "@/app/signup/signup-form";
-import {AnonymousAllowedRoute} from "@/components/contexts/route-accessibility";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { SignUpForm } from "@/app/signup/signup-form";
+import { AnonymousAllowedRoute } from "@/components/contexts/route-accessibility";
 
 export default function SignupPage() {
-
 	return (
 		<AnonymousAllowedRoute>
 			<div className="flex min-h-screen -mt-24 items-center justify-center px-4">
 				<Card className="w-full max-w-md border-border/40 bg-card/60 backdrop-blur-sm z-50">
 					<CardHeader className="space-y-1">
 						<CardTitle className="text-2xl font-bold">Create an account</CardTitle>
-						<CardDescription>
-							Enter your information to create an account
-						</CardDescription>
+						<CardDescription>Enter your information to create an account</CardDescription>
 					</CardHeader>
 					<CardContent className="space-y-4">
-						<SignUpForm/>
+						<SignUpForm />
 					</CardContent>
 					<CardFooter className="flex flex-col space-y-4 pt-4">
 						<div className="text-center text-sm">
-							<Link
-								href="/login"
-								className="text-primary hover:underline"
-							>
+							<Link href="/login" className="text-primary hover:underline">
 								Already have an account? Sign in
 							</Link>
 						</div>
@@ -32,5 +26,5 @@ export default function SignupPage() {
 				</Card>
 			</div>
 		</AnonymousAllowedRoute>
-	)
+	);
 }

--- a/web/app/signup/signup-form.tsx
+++ b/web/app/signup/signup-form.tsx
@@ -1,31 +1,33 @@
-"use client"
+"use client";
 
-import {zodResolver} from "@hookform/resolvers/zod"
-import {useForm} from "react-hook-form"
-import {z} from "zod"
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
 
-import {Button} from "@/components/ui/button"
-import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage,} from "@/components/ui/form"
-import {Input} from "@/components/ui/input"
-import {submitSignup} from "@/components/api/user-api";
-import {useRouter} from "next/navigation";
-import {useState} from "react";
-import {EyeIcon, EyeOffIcon} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { submitSignup } from "@/components/api/user-api";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { EyeIcon, EyeOffIcon } from "lucide-react";
 
-const FormSchema = z.object({
-	username: z.string().min(5).max(30),
-	email: z.string().email(),
-	password: z.string().min(8).max(30),
-	confirmPassword: z.string().min(8).max(30),
-}).refine((data) => data.password === data.confirmPassword, {
-	message: "Passwords don't match",
-	path: ['confirmPassword'],
-})
+const FormSchema = z
+	.object({
+		username: z.string().min(5).max(30),
+		email: z.string().email(),
+		password: z.string().min(8).max(30),
+		confirmPassword: z.string().min(8).max(30),
+	})
+	.refine((data) => data.password === data.confirmPassword, {
+		message: "Passwords don't match",
+		path: ["confirmPassword"],
+	});
 
 export function SignUpForm() {
 	const [showPassword, setShowPassword] = useState(false);
 	const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-	const [isSubmitLoading, setSubmitLoading] = useState(false)
+	const [isSubmitLoading, setSubmitLoading] = useState(false);
 	const [errorMessage, setErrorMessage] = useState("");
 	const router = useRouter();
 
@@ -37,67 +39,63 @@ export function SignUpForm() {
 			password: "",
 			confirmPassword: "",
 		},
-	})
+	});
 
 	function onSubmit(data: z.infer<typeof FormSchema>) {
 		setSubmitLoading(true);
 		submitSignup(data.username, data.email, data.password)
-			.then(response => {
+			.then((response) => {
 				if (response.error) throw new Error(response.error);
 				if (!response.data) throw new Error("Faulty response");
 				if (response.data.usernameTaken) throw new Error("Username already taken");
-				if (response.data.emailTaken) throw new Error("Email already associated with a different account")
+				if (response.data.emailTaken) throw new Error("Email already associated with a different account");
 				if (!response.data.signupSuccess) throw new Error("Signup failed. Please try again");
 				setErrorMessage("");
 				router.push("/login?signup=success");
 			})
-			.catch(error => {
+			.catch((error) => {
 				setErrorMessage(error.message);
 			})
 			.finally(() => {
 				setTimeout(() => setSubmitLoading(false), 1000);
-			})
+			});
 	}
 
 	return (
 		<div>
-			{errorMessage && (
-				<div className="bg-destructive/15 text-destructive text-sm p-3 rounded-md mb-4">
-					{errorMessage}
-				</div>
-			)}
+			{errorMessage && <div className="bg-destructive/15 text-destructive text-sm p-3 rounded-md mb-4">{errorMessage}</div>}
 			<Form {...form}>
 				<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
 					<FormField
 						control={form.control}
 						name="username"
-						render={({field}) => (
+						render={({ field }) => (
 							<FormItem>
 								<FormLabel>Username</FormLabel>
 								<FormControl>
 									<Input {...field} />
 								</FormControl>
-								<FormMessage/>
+								<FormMessage />
 							</FormItem>
 						)}
 					/>
 					<FormField
 						control={form.control}
 						name="email"
-						render={({field}) => (
+						render={({ field }) => (
 							<FormItem>
 								<FormLabel>E-Mail</FormLabel>
 								<FormControl>
 									<Input {...field} />
 								</FormControl>
-								<FormMessage/>
+								<FormMessage />
 							</FormItem>
 						)}
 					/>
 					<FormField
 						control={form.control}
 						name="password"
-						render={({field}) => (
+						render={({ field }) => (
 							<FormItem>
 								<FormLabel>Password</FormLabel>
 								<FormControl>
@@ -110,25 +108,19 @@ export function SignUpForm() {
 											className="absolute right-0 top-0 h-full px-3 py-2 text-muted-foreground hover:text-foreground"
 											onClick={() => setShowPassword(!showPassword)}
 										>
-											{showPassword ? (
-												<EyeOffIcon className="h-4 w-4"/>
-											) : (
-												<EyeIcon className="h-4 w-4"/>
-											)}
-											<span className="sr-only">
-                                                {showPassword ? "Hide password" : "Show password"}
-                                            </span>
+											{showPassword ? <EyeOffIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}
+											<span className="sr-only">{showPassword ? "Hide password" : "Show password"}</span>
 										</Button>
 									</div>
 								</FormControl>
-								<FormMessage/>
+								<FormMessage />
 							</FormItem>
 						)}
 					/>
 					<FormField
 						control={form.control}
 						name="confirmPassword"
-						render={({field}) => (
+						render={({ field }) => (
 							<FormItem>
 								<FormLabel>Confirm Password</FormLabel>
 								<FormControl>
@@ -141,30 +133,20 @@ export function SignUpForm() {
 											className="absolute right-0 top-0 h-full px-3 py-2 text-muted-foreground hover:text-foreground"
 											onClick={() => setShowConfirmPassword(!showConfirmPassword)}
 										>
-											{showConfirmPassword ? (
-												<EyeOffIcon className="h-4 w-4"/>
-											) : (
-												<EyeIcon className="h-4 w-4"/>
-											)}
-											<span className="sr-only">
-                                                {showConfirmPassword ? "Hide password" : "Show password"}
-                                            </span>
+											{showConfirmPassword ? <EyeOffIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}
+											<span className="sr-only">{showConfirmPassword ? "Hide password" : "Show password"}</span>
 										</Button>
 									</div>
 								</FormControl>
-								<FormMessage/>
+								<FormMessage />
 							</FormItem>
 						)}
 					/>
-					<Button
-						type="submit"
-						className="w-full"
-						disabled={isSubmitLoading}
-					>
+					<Button type="submit" className="w-full" disabled={isSubmitLoading}>
 						{isSubmitLoading ? "Creating account..." : "Create account"}
 					</Button>
 				</form>
 			</Form>
 		</div>
-	)
+	);
 }

--- a/web/app/user/[username]/anilist/anime/page.tsx
+++ b/web/app/user/[username]/anilist/anime/page.tsx
@@ -1,10 +1,10 @@
-import {ProtectedRoute} from "@/components/contexts/route-accessibility";
+import { ProtectedRoute } from "@/components/contexts/route-accessibility";
 import TierListPage from "@/components/tierlist/tier-list-page";
 
 export default function AniListAnime() {
 	return (
 		<ProtectedRoute>
-			<TierListPage title={"AniList Anime Tier List"} provider={"anilist-anime"}/>
+			<TierListPage title={"AniList Anime Tier List"} provider={"anilist-anime"} />
 		</ProtectedRoute>
 	);
 }

--- a/web/app/user/[username]/anilist/manga/page.tsx
+++ b/web/app/user/[username]/anilist/manga/page.tsx
@@ -1,10 +1,10 @@
-import {ProtectedRoute} from "@/components/contexts/route-accessibility";
+import { ProtectedRoute } from "@/components/contexts/route-accessibility";
 import TierListPage from "@/components/tierlist/tier-list-page";
 
 export default function AniListManga() {
 	return (
 		<ProtectedRoute>
-			<TierListPage title={"AniList Manga Tier List"} provider={"anilist-manga"}/>
+			<TierListPage title={"AniList Manga Tier List"} provider={"anilist-manga"} />
 		</ProtectedRoute>
 	);
 }

--- a/web/app/user/[username]/page.tsx
+++ b/web/app/user/[username]/page.tsx
@@ -1,30 +1,29 @@
-"use client"
-import {Avatar, AvatarFallback} from "@/components/ui/avatar"
-import React, {useEffect, useState} from "react";
-import {ProtectedRoute} from "@/components/contexts/route-accessibility";
-import {useAuth} from "@/components/contexts/auth-context";
-import {fetchUser} from "@/components/api/user-api";
-import {useParams} from "next/navigation";
+"use client";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import React, { useEffect, useState } from "react";
+import { ProtectedRoute } from "@/components/contexts/route-accessibility";
+import { useAuth } from "@/components/contexts/auth-context";
+import { fetchUser } from "@/components/api/user-api";
+import { useParams } from "next/navigation";
 import LoadingPage from "@/components/loading-skeletons/loading-page";
-import {cn} from "@/lib/utils"
-import {Card, CardContent, CardHeader} from "@/components/ui/card";
-import {UserResponse} from "@/components/model/response-types";
-import {fetchConfiguredServices} from "@/components/api/config-api";
+import { cn } from "@/lib/utils";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { UserResponse } from "@/components/model/response-types";
+import { fetchConfiguredServices } from "@/components/api/config-api";
 import TierlistLink from "@/app/user/[username]/tierlist-link";
-
 
 export default function Profile() {
 	const params = useParams<{ username: string }>();
 	const username: string = params.username;
 	const [userResponse, setUserResponse] = useState<UserResponse>();
-	const {token, isLoading, isAuthenticated, logout} = useAuth();
+	const { token, isLoading, isAuthenticated, logout } = useAuth();
 
 	const [configuredServices, setConfiguredServices] = useState<string[]>();
 
 	useEffect(() => {
 		if (!isLoading && isAuthenticated) {
 			fetchUser(token, username)
-				.then(response => {
+				.then((response) => {
 					if (response.status === 401 || response.status === 403) {
 						logout();
 						throw new Error("Session expired");
@@ -34,14 +33,14 @@ export default function Profile() {
 					if (!response.data) throw new Error("Faulty response");
 					setUserResponse(response.data);
 				})
-				.catch((error) => console.error(error))
+				.catch((error) => console.error(error));
 		}
 	}, [username, isLoading, isAuthenticated, token, logout]);
 
 	useEffect(() => {
 		if (!isLoading && isAuthenticated) {
 			fetchConfiguredServices(token)
-				.then(response => {
+				.then((response) => {
 					if (response.status === 401 || response.status === 403) {
 						logout();
 						throw new Error("Session expired");
@@ -51,20 +50,22 @@ export default function Profile() {
 					if (!response.data) throw new Error("Faulty response");
 					setConfiguredServices(response.data);
 				})
-				.catch((error) => console.error(error))
+				.catch((error) => console.error(error));
 		}
-	}, [isAuthenticated, isLoading, logout, token])
+	}, [isAuthenticated, isLoading, logout, token]);
 
-	if (!userResponse || !configuredServices) return <LoadingPage/>
+	if (!userResponse || !configuredServices) return <LoadingPage />;
 
 	return (
 		<ProtectedRoute>
 			<div className="flex min-h-screen -mt-24 items-center justify-center px-4">
-				<Card className={cn(
-					"w-full max-w-md",
-					"flex flex-col rounded-2xl",
-					"bg-card/60 backdrop-blur-sm border border-border/100 shadow-lg",
-				)}>
+				<Card
+					className={cn(
+						"w-full max-w-md",
+						"flex flex-col rounded-2xl",
+						"bg-card/60 backdrop-blur-sm border border-border/100 shadow-lg"
+					)}
+				>
 					<CardHeader className="flex flex-row items-center text-center pb-6">
 						<Avatar className="h-24 w-24 border-2 border-border/50 shadow-md">
 							{/*<AvatarImage src={"/avatar.svg"} alt={username}/>*/}
@@ -78,25 +79,30 @@ export default function Profile() {
 
 					<CardContent className="space-y-4">
 						<div className="grid columns-1 gap-4">
-							{userResponse.connectedServices.includes('ANILIST') &&
-                                <TierlistLink service={"anilist"} type={"anime"} title={"Anime"}
-                                              username={userResponse.username}/>}
-							{userResponse.connectedServices.includes('ANILIST') &&
-                                <TierlistLink service={"anilist"} type={"manga"} title={"Manga"}
-                                              username={userResponse.username}/>}
-							{userResponse.connectedServices.includes('TRAKT') &&
-                                <TierlistLink service={"trakt"} type={"movies"} title={"Movies"}
-                                              username={userResponse.username}/>}
-							{userResponse.connectedServices.includes('TRAKT') &&
-                                <TierlistLink service={"trakt"} type={"tvshows"} title={"TV Shows"}
-                                              username={userResponse.username}/>}
-							{userResponse.connectedServices.includes('TRAKT') &&
-                                <TierlistLink service={"trakt"} type={"tvshows-seasons"} title={"TV Shows - Seasons"}
-                                              username={userResponse.username}/>}
+							{userResponse.connectedServices.includes("ANILIST") && (
+								<TierlistLink service={"anilist"} type={"anime"} title={"Anime"} username={userResponse.username} />
+							)}
+							{userResponse.connectedServices.includes("ANILIST") && (
+								<TierlistLink service={"anilist"} type={"manga"} title={"Manga"} username={userResponse.username} />
+							)}
+							{userResponse.connectedServices.includes("TRAKT") && (
+								<TierlistLink service={"trakt"} type={"movies"} title={"Movies"} username={userResponse.username} />
+							)}
+							{userResponse.connectedServices.includes("TRAKT") && (
+								<TierlistLink service={"trakt"} type={"tvshows"} title={"TV Shows"} username={userResponse.username} />
+							)}
+							{userResponse.connectedServices.includes("TRAKT") && (
+								<TierlistLink
+									service={"trakt"}
+									type={"tvshows-seasons"}
+									title={"TV Shows - Seasons"}
+									username={userResponse.username}
+								/>
+							)}
 						</div>
 					</CardContent>
 				</Card>
 			</div>
 		</ProtectedRoute>
-	)
+	);
 }

--- a/web/app/user/[username]/tierlist-link.tsx
+++ b/web/app/user/[username]/tierlist-link.tsx
@@ -1,31 +1,30 @@
-import {ButtonGroup} from "@/components/ui/button-group";
-import {Button} from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import React from "react";
 import Image from "next/image";
 
-export default function TierlistLink({service, type, title, username}: {
-	service: string,
-	type: string,
-	title: string,
-	username: string
+export default function TierlistLink({
+	service,
+	type,
+	title,
+	username,
+}: {
+	service: string;
+	type: string;
+	title: string;
+	username: string;
 }) {
 	return (
 		<ButtonGroup className={"w-full flex"}>
 			<Button variant="outline" className={"grow"}>
 				<Link href={`/user/${username}/${service}/${type}`} className="w-full flex justify-center">
 					<div className="relative w-5 h-5 mr-auto">
-						<Image
-							src={`/icons/${service}.svg`}
-							alt={`${service} icon`}
-							fill={true}
-						/>
+						<Image src={`/icons/${service}.svg`} alt={`${service} icon`} fill={true} />
 					</div>
-					<div className="text-center absolute">
-						{title}
-					</div>
+					<div className="text-center absolute">{title}</div>
 				</Link>
 			</Button>
 		</ButtonGroup>
-	)
+	);
 }

--- a/web/app/user/[username]/trakt/movies/page.tsx
+++ b/web/app/user/[username]/trakt/movies/page.tsx
@@ -1,10 +1,10 @@
-import {ProtectedRoute} from "@/components/contexts/route-accessibility";
+import { ProtectedRoute } from "@/components/contexts/route-accessibility";
 import TierListPage from "@/components/tierlist/tier-list-page";
 
 export default function TraktMovies() {
 	return (
 		<ProtectedRoute>
-			<TierListPage title={"Trakt Movies Tier List"} provider={"trakt-movies"}/>
+			<TierListPage title={"Trakt Movies Tier List"} provider={"trakt-movies"} />
 		</ProtectedRoute>
 	);
 }

--- a/web/app/user/[username]/trakt/tvshows-seasons/page.tsx
+++ b/web/app/user/[username]/trakt/tvshows-seasons/page.tsx
@@ -1,10 +1,10 @@
-import {ProtectedRoute} from "@/components/contexts/route-accessibility";
+import { ProtectedRoute } from "@/components/contexts/route-accessibility";
 import TierListPage from "@/components/tierlist/tier-list-page";
 
 export default function TraktTvShowsSeasons() {
 	return (
 		<ProtectedRoute>
-			<TierListPage title={"Trakt TV Shows Tier List"} provider={"trakt-tvshows-seasons"}/>
+			<TierListPage title={"Trakt TV Shows Tier List"} provider={"trakt-tvshows-seasons"} />
 		</ProtectedRoute>
 	);
 }

--- a/web/app/user/[username]/trakt/tvshows/page.tsx
+++ b/web/app/user/[username]/trakt/tvshows/page.tsx
@@ -1,10 +1,10 @@
-import {ProtectedRoute} from "@/components/contexts/route-accessibility";
+import { ProtectedRoute } from "@/components/contexts/route-accessibility";
 import TierListPage from "@/components/tierlist/tier-list-page";
 
 export default function TraktTvshows() {
 	return (
 		<ProtectedRoute>
-			<TierListPage title={"Trakt TV Shows Tier List"} provider={"trakt-tvshows"}/>
+			<TierListPage title={"Trakt TV Shows Tier List"} provider={"trakt-tvshows"} />
 		</ProtectedRoute>
 	);
 }

--- a/web/app/user/page.tsx
+++ b/web/app/user/page.tsx
@@ -1,13 +1,13 @@
-"use client"
+"use client";
 
-import {useAuth} from "@/components/contexts/auth-context";
-import {useRouter} from "next/navigation";
-import {ProtectedRoute} from "@/components/contexts/route-accessibility";
+import { useAuth } from "@/components/contexts/auth-context";
+import { useRouter } from "next/navigation";
+import { ProtectedRoute } from "@/components/contexts/route-accessibility";
 import LoadingPage from "@/components/loading-skeletons/loading-page";
-import {useEffect} from "react";
+import { useEffect } from "react";
 
 export default function RedirectToUser() {
-	const {user, isLoading, isAuthenticated} = useAuth();
+	const { user, isLoading, isAuthenticated } = useAuth();
 	const router = useRouter();
 
 	useEffect(() => {
@@ -15,12 +15,11 @@ export default function RedirectToUser() {
 			if (isAuthenticated) router.push(`/user/${user}`);
 			else router.push("/login");
 		}
-
-	}, [isLoading, isAuthenticated, router, user])
+	}, [isLoading, isAuthenticated, router, user]);
 
 	return (
 		<ProtectedRoute>
-			<LoadingPage/>
+			<LoadingPage />
 		</ProtectedRoute>
-	)
+	);
 }

--- a/web/components.json
+++ b/web/components.json
@@ -1,21 +1,21 @@
 {
-  "$schema": "https://ui.shadcn.com/schema.json",
-  "style": "new-york",
-  "rsc": true,
-  "tsx": true,
-  "tailwind": {
-    "config": "",
-    "css": "app/globals.css",
-    "baseColor": "slate",
-    "cssVariables": true,
-    "prefix": ""
-  },
-  "aliases": {
-    "components": "@/components",
-    "utils": "@/lib/utils",
-    "ui": "@/components/ui",
-    "lib": "@/lib",
-    "hooks": "@/hooks"
-  },
-  "iconLibrary": "lucide"
+	"$schema": "https://ui.shadcn.com/schema.json",
+	"style": "new-york",
+	"rsc": true,
+	"tsx": true,
+	"tailwind": {
+		"config": "",
+		"css": "app/globals.css",
+		"baseColor": "slate",
+		"cssVariables": true,
+		"prefix": ""
+	},
+	"aliases": {
+		"components": "@/components",
+		"utils": "@/lib/utils",
+		"ui": "@/components/ui",
+		"lib": "@/lib",
+		"hooks": "@/hooks"
+	},
+	"iconLibrary": "lucide"
 }

--- a/web/components/api/auth-api.tsx
+++ b/web/components/api/auth-api.tsx
@@ -1,50 +1,54 @@
-"use server"
+"use server";
 
-import {API_URL} from "@/components/global-config";
-import {ServerResponse, ThirdPartyAuthResponse, ThirdPartyInfoResponse} from "@/components/model/response-types";
+import { API_URL } from "@/components/global-config";
+import { ServerResponse, ThirdPartyAuthResponse, ThirdPartyInfoResponse } from "@/components/model/response-types";
 
-export default async function authorize(service: string, username: string | null, token: string | null, code: string | null): Promise<ServerResponse<ThirdPartyAuthResponse>> {
+export default async function authorize(
+	service: string,
+	username: string | null,
+	token: string | null,
+	code: string | null
+): Promise<ServerResponse<ThirdPartyAuthResponse>> {
 	if (!username && !token && !code) {
-		throw new Error("Invalid username, token or code")
+		throw new Error("Invalid username, token or code");
 	}
 
 	try {
 		const response = await fetch(`${API_URL}/auth/${service}/${username}`, {
-			method: 'POST',
+			method: "POST",
 			headers: {
-				"Authorization": "Bearer " + token,
-				"Content-Type": "application/json"
+				Authorization: "Bearer " + token,
+				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({code})
+			body: JSON.stringify({ code }),
 		});
 
-		const data = await response.json().catch(() => null)
-		return {data, status: response.status};
+		const data = await response.json().catch(() => null);
+		return { data, status: response.status };
 	} catch (error) {
-		console.error('API proxy error: ', error);
-		return {error: 'Server unavailable', status: 500}
+		console.error("API proxy error: ", error);
+		return { error: "Server unavailable", status: 500 };
 	}
 }
 
 export async function info(service: string, token: string | null): Promise<ServerResponse<ThirdPartyInfoResponse>> {
 	if (!token) {
-		throw new Error("Invalid token")
+		throw new Error("Invalid token");
 	}
 
 	try {
 		const response = await fetch(`${API_URL}/info/${service}`, {
-			method: 'GET',
+			method: "GET",
 			headers: {
-				"Authorization": "Bearer " + token,
-				"Content-Type": "application/json"
-			}
+				Authorization: "Bearer " + token,
+				"Content-Type": "application/json",
+			},
 		});
 
-		const data = await response.json().catch(() => null)
-		return {data, status: response.status};
+		const data = await response.json().catch(() => null);
+		return { data, status: response.status };
 	} catch (error) {
-		console.error('API proxy error: ', error);
-		return {error: 'Server unavailable', status: 500}
+		console.error("API proxy error: ", error);
+		return { error: "Server unavailable", status: 500 };
 	}
 }
-

--- a/web/components/api/config-api.tsx
+++ b/web/components/api/config-api.tsx
@@ -1,24 +1,24 @@
-"use server"
+"use server";
 
-import {ServerResponse} from "@/components/model/response-types";
-import {API_URL} from "@/components/global-config";
+import { ServerResponse } from "@/components/model/response-types";
+import { API_URL } from "@/components/global-config";
 
 export const fetchConfiguredServices = async (token: string | null): Promise<ServerResponse<string[]>> => {
 	if (!token) throw new Error("No authentication token");
 
 	try {
 		const response = await fetch(`${API_URL}/config/services`, {
-			method: 'GET',
+			method: "GET",
 			headers: {
-				"Authorization": `Bearer ${token}`,
+				Authorization: `Bearer ${token}`,
 				"Content-Type": "application/json",
-			}
+			},
 		});
 
-		const data = await response.json().catch(() => null)
-		return {data, status: response.status};
+		const data = await response.json().catch(() => null);
+		return { data, status: response.status };
 	} catch (error) {
-		console.error('API proxy error: ', error);
-		return {error: 'Server unavailable', status: 500}
+		console.error("API proxy error: ", error);
+		return { error: "Server unavailable", status: 500 };
 	}
-}
+};

--- a/web/components/api/data-api.tsx
+++ b/web/components/api/data-api.tsx
@@ -1,37 +1,49 @@
-"use server"
+"use server";
 
-import {API_URL} from "@/components/global-config";
-import {GenericErrorResponse, ServerResponse} from "@/components/model/response-types";
-import {TierlistEntry} from "@/components/model/types";
+import { API_URL } from "@/components/global-config";
+import { GenericErrorResponse, ServerResponse } from "@/components/model/response-types";
+import { TierlistEntry } from "@/components/model/types";
 
-export const fetchData = async (token: string | null, username: string, service: string, type: string): Promise<ServerResponse<TierlistEntry[]>> => {
+export const fetchData = async (
+	token: string | null,
+	username: string,
+	service: string,
+	type: string
+): Promise<ServerResponse<TierlistEntry[]>> => {
 	if (!token) throw new Error("No authentication token");
 
 	try {
 		const response = await fetch(`${API_URL}/data/fetch/${username}/${service}/${type}`, {
-			method: 'GET',
+			method: "GET",
 			headers: {
-				"Authorization": `Bearer ${token}`,
+				Authorization: `Bearer ${token}`,
 				"Content-Type": "application/json",
-			}
+			},
 		});
 
-		const data = await response.json().catch(() => null)
-		return {data, status: response.status};
+		const data = await response.json().catch(() => null);
+		return { data, status: response.status };
 	} catch (error) {
-		console.error('API proxy error: ', error);
-		return {error: 'Server unavailable', status: 500}
+		console.error("API proxy error: ", error);
+		return { error: "Server unavailable", status: 500 };
 	}
-}
+};
 
-export async function updateData(id: string, score: number, service: string, type: string, token: string | null, username: string): Promise<ServerResponse<GenericErrorResponse>> {
+export async function updateData(
+	id: string,
+	score: number,
+	service: string,
+	type: string,
+	token: string | null,
+	username: string
+): Promise<ServerResponse<GenericErrorResponse>> {
 	if (!token) throw new Error("No authentication token");
 
 	try {
 		const response = await fetch(`${API_URL}/data/update`, {
-			method: 'POST',
+			method: "POST",
 			headers: {
-				"Authorization": `Bearer ${token}`,
+				Authorization: `Bearer ${token}`,
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({
@@ -40,33 +52,38 @@ export async function updateData(id: string, score: number, service: string, typ
 				username: username,
 				service: service,
 				type: type,
-			})
+			}),
 		});
 
-		const data = await response.json().catch(() => null)
-		return {data, status: response.status};
+		const data = await response.json().catch(() => null);
+		return { data, status: response.status };
 	} catch (error) {
-		console.error('API proxy error: ', error);
-		return {error: 'Server unavailable', status: 500}
+		console.error("API proxy error: ", error);
+		return { error: "Server unavailable", status: 500 };
 	}
 }
 
-export async function pullData(token: string | null, username: string, service: string, type: string): Promise<ServerResponse<GenericErrorResponse>> {
+export async function pullData(
+	token: string | null,
+	username: string,
+	service: string,
+	type: string
+): Promise<ServerResponse<GenericErrorResponse>> {
 	if (!token) throw new Error("No authentication token");
 
 	try {
 		const response = await fetch(`${API_URL}/data/pull/${username}/${service}/${type}`, {
-			method: 'GET',
+			method: "GET",
 			headers: {
-				"Authorization": `Bearer ${token}`,
+				Authorization: `Bearer ${token}`,
 				"Content-Type": "application/json",
-			}
+			},
 		});
 
-		const data = await response.json().catch(() => null)
-		return {data, status: response.status};
+		const data = await response.json().catch(() => null);
+		return { data, status: response.status };
 	} catch (error) {
-		console.error('API proxy error: ', error);
-		return {error: 'Server unavailable', status: 500}
+		console.error("API proxy error: ", error);
+		return { error: "Server unavailable", status: 500 };
 	}
 }

--- a/web/components/api/tier-api.tsx
+++ b/web/components/api/tier-api.tsx
@@ -1,47 +1,57 @@
-"use server"
+"use server";
 
-import {API_URL} from "@/components/global-config";
-import {Tier} from "@/components/model/types";
-import {ServerResponse} from "@/components/model/response-types";
+import { API_URL } from "@/components/global-config";
+import { Tier } from "@/components/model/types";
+import { ServerResponse } from "@/components/model/response-types";
 
-export const fetchTiers = async (token: string | null, username: string, service: string, type: string): Promise<ServerResponse<Tier[]>> => {
-	if (!token) throw new Error("No authentication token")
+export const fetchTiers = async (
+	token: string | null,
+	username: string,
+	service: string,
+	type: string
+): Promise<ServerResponse<Tier[]>> => {
+	if (!token) throw new Error("No authentication token");
 
 	try {
 		const response = await fetch(`${API_URL}/tiers/${username}/${service}/${type.toLowerCase()}`, {
-			method: 'GET',
+			method: "GET",
 			headers: {
 				"Content-Type": "application/json",
-				"Authorization": `Bearer ${token}`,
-			}
+				Authorization: `Bearer ${token}`,
+			},
 		});
 
-		const data = await response.json().catch(() => null)
-		return {data, status: response.status};
+		const data = await response.json().catch(() => null);
+		return { data, status: response.status };
 	} catch (error) {
-		console.error('API proxy error: ', error);
-		return {error: 'Server unavailable', status: 500}
+		console.error("API proxy error: ", error);
+		return { error: "Server unavailable", status: 500 };
 	}
-}
+};
 
-export async function updateTiers(token: string | null, username: string, service: string, type: string, tiers: Tier[]): Promise<ServerResponse<any>> {
-	if (!token) throw new Error("No authentication token")
+export async function updateTiers(
+	token: string | null,
+	username: string,
+	service: string,
+	type: string,
+	tiers: Tier[]
+): Promise<ServerResponse<any>> {
+	if (!token) throw new Error("No authentication token");
 
 	try {
 		const response = await fetch(`${API_URL}/tiers/${username}/${service}/${type}`, {
-			method: 'POST',
+			method: "POST",
 			headers: {
-				"Authorization": `Bearer ${token}`,
-				"Content-Type": "application/json"
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
 			},
-			body: JSON.stringify(tiers)
+			body: JSON.stringify(tiers),
 		});
 
-		const data = await response.json().catch(() => null)
-		return {data, status: response.status};
+		const data = await response.json().catch(() => null);
+		return { data, status: response.status };
 	} catch (error) {
-		console.error('API proxy error: ', error);
-		return {error: 'Server unavailable', status: 500}
+		console.error("API proxy error: ", error);
+		return { error: "Server unavailable", status: 500 };
 	}
-
 }

--- a/web/components/api/user-api.tsx
+++ b/web/components/api/user-api.tsx
@@ -1,47 +1,41 @@
-"use server"
-import {API_URL} from "@/components/global-config";
-import {
-	GenericErrorResponse,
-	LoginResponse,
-	ServerResponse,
-	SignupResponse,
-	UserResponse
-} from "@/components/model/response-types";
+"use server";
+import { API_URL } from "@/components/global-config";
+import { GenericErrorResponse, LoginResponse, ServerResponse, SignupResponse, UserResponse } from "@/components/model/response-types";
 
 export async function requestLogin(username: string, password: string): Promise<ServerResponse<LoginResponse>> {
 	try {
 		const response = await fetch(`${API_URL}/auth/login`, {
-			method: 'POST',
+			method: "POST",
 			headers: {
-				'Content-Type': 'application/json',
-				'Accept': 'application/json'
+				"Content-Type": "application/json",
+				Accept: "application/json",
 			},
-			body: JSON.stringify({username, password}),
+			body: JSON.stringify({ username, password }),
 		});
 
-		const data = await response.json().catch(() => null)
-		return {data, status: response.status};
+		const data = await response.json().catch(() => null);
+		return { data, status: response.status };
 	} catch (error) {
-		console.error('API proxy error: ', error);
-		return {error: 'Server unavailable', status: 500}
+		console.error("API proxy error: ", error);
+		return { error: "Server unavailable", status: 500 };
 	}
 }
 
 export async function submitSignup(username: string, email: string, password: string): Promise<ServerResponse<SignupResponse>> {
 	try {
 		const response = await fetch(`${API_URL}/auth/signup`, {
-			method: 'POST',
+			method: "POST",
 			headers: {
-				'Content-Type': 'application/json',
+				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({username, email, password}),
+			body: JSON.stringify({ username, email, password }),
 		});
 
-		const data = await response.json().catch(() => null)
-		return {data, status: response.status};
+		const data = await response.json().catch(() => null);
+		return { data, status: response.status };
 	} catch (error) {
-		console.error('API proxy error: ', error);
-		return {error: 'Server unavailable', status: 500}
+		console.error("API proxy error: ", error);
+		return { error: "Server unavailable", status: 500 };
 	}
 }
 
@@ -50,40 +44,45 @@ export async function refreshToken(token: string | null): Promise<ServerResponse
 
 	try {
 		const response = await fetch(`${API_URL}/auth/refresh`, {
-			method: 'POST',
+			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				"Authorization": `Bearer ${token}`,
+				Authorization: `Bearer ${token}`,
 			},
-			body: JSON.stringify({token}),
-		})
+			body: JSON.stringify({ token }),
+		});
 
 		const data = await response.json().catch(() => null);
-		return {data, status: response.status};
+		return { data, status: response.status };
 	} catch (error) {
-		console.error('API proxy error: ', error);
-		return {error: 'Server unavailable', status: 500}
+		console.error("API proxy error: ", error);
+		return { error: "Server unavailable", status: 500 };
 	}
 }
 
-export async function changePassword(oldPassword: string, newPassword: string, username: string | null, token: string | null): Promise<ServerResponse<GenericErrorResponse>> {
+export async function changePassword(
+	oldPassword: string,
+	newPassword: string,
+	username: string | null,
+	token: string | null
+): Promise<ServerResponse<GenericErrorResponse>> {
 	if (!username || !token) throw new Error("Invalid user or authentication token");
 
 	try {
 		const response = await fetch(`${API_URL}/auth/change-password`, {
-			method: 'POST',
+			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				"Authorization": `Bearer ${token}`,
+				Authorization: `Bearer ${token}`,
 			},
-			body: JSON.stringify({oldPassword, newPassword, username}),
-		})
+			body: JSON.stringify({ oldPassword, newPassword, username }),
+		});
 
 		const data = await response.json().catch(() => null);
-		return {data, status: response.status};
+		return { data, status: response.status };
 	} catch (error) {
-		console.error('API proxy error: ', error);
-		return {error: 'Server unavailable', status: 500}
+		console.error("API proxy error: ", error);
+		return { error: "Server unavailable", status: 500 };
 	}
 }
 
@@ -92,58 +91,62 @@ export async function deleteAccount(username: string | null, token: string | nul
 
 	try {
 		const response = await fetch(`${API_URL}/auth/delete-account`, {
-			method: 'POST',
+			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				"Authorization": `Bearer ${token}`,
+				Authorization: `Bearer ${token}`,
 			},
-			body: JSON.stringify({username}),
-		})
+			body: JSON.stringify({ username }),
+		});
 
 		const data = await response.json().catch(() => null);
-		return {data, status: response.status};
+		return { data, status: response.status };
 	} catch (error) {
-		console.error('API proxy error: ', error);
-		return {error: 'Server unavailable', status: 500}
+		console.error("API proxy error: ", error);
+		return { error: "Server unavailable", status: 500 };
 	}
 }
 
-export async function removeConnection(service: string, username: string | null, token: string | null): Promise<ServerResponse<GenericErrorResponse>> {
+export async function removeConnection(
+	service: string,
+	username: string | null,
+	token: string | null
+): Promise<ServerResponse<GenericErrorResponse>> {
 	if (!username || !token) throw new Error("Invalid user or authentication token");
 
 	try {
 		const response = await fetch(`${API_URL}/user/${username}/remove/${service}`, {
-			method: 'POST',
+			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				"Authorization": `Bearer ${token}`,
+				Authorization: `Bearer ${token}`,
 			},
-		})
+		});
 
 		const data = await response.json().catch(() => null);
-		return {data, status: response.status};
+		return { data, status: response.status };
 	} catch (error) {
-		console.error('API proxy error: ', error);
-		return {error: 'Server unavailable', status: 500}
+		console.error("API proxy error: ", error);
+		return { error: "Server unavailable", status: 500 };
 	}
 }
 
 export async function fetchUser(token: string | null, username: string): Promise<ServerResponse<UserResponse>> {
-	if (!token) throw new Error("No authentication token")
+	if (!token) throw new Error("No authentication token");
 
 	try {
 		const response = await fetch(`${API_URL}/user/${username}`, {
-			method: 'GET',
+			method: "GET",
 			headers: {
 				"Content-Type": "application/json",
-				"Authorization": `Bearer ${token}`,
-			}
+				Authorization: `Bearer ${token}`,
+			},
 		});
 
-		const data = await response.json().catch(() => null)
-		return {data, status: response.status};
+		const data = await response.json().catch(() => null);
+		return { data, status: response.status };
 	} catch (error) {
-		console.error('API proxy error: ', error);
-		return {error: 'Server unavailable', status: 500}
+		console.error("API proxy error: ", error);
+		return { error: "Server unavailable", status: 500 };
 	}
 }

--- a/web/components/auth/jwt-decoder.tsx
+++ b/web/components/auth/jwt-decoder.tsx
@@ -1,4 +1,4 @@
-import {jwtDecode} from 'jwt-decode';
+import { jwtDecode } from "jwt-decode";
 
 interface JwtPayload {
 	sub?: string;
@@ -15,24 +15,23 @@ export function extractJwtData(token: string): {
 	expiration: Date | null;
 	isExpired: boolean;
 } | null {
-
 	if (!token) {
 		return null;
 	}
 
 	try {
 		const decoded = jwtDecode<JwtPayload>(token);
-		const username = decoded.sub || '';
+		const username = decoded.sub || "";
 		const expiration = decoded.exp ? new Date(decoded.exp * 1000) : null;
 		const isExpired = expiration ? new Date() > expiration : false;
 
 		return {
 			username,
 			expiration,
-			isExpired
+			isExpired,
 		};
 	} catch (error) {
-		console.error('Failed to decode JWT:', error);
+		console.error("Failed to decode JWT:", error);
 		return null;
 	}
 }

--- a/web/components/auth/logout-button.tsx
+++ b/web/components/auth/logout-button.tsx
@@ -1,21 +1,15 @@
-"use client"
+"use client";
 
-import {Button} from "@/components/ui/button";
-import {LogOut} from "lucide-react";
-import {useAuth} from "@/components/contexts/auth-context";
+import { Button } from "@/components/ui/button";
+import { LogOut } from "lucide-react";
+import { useAuth } from "@/components/contexts/auth-context";
 
 export default function LogoutButton() {
-	const {logout} = useAuth()
+	const { logout } = useAuth();
 
 	return (
-		<Button
-			variant="ghost"
-			size="icon"
-			onClick={logout}
-			className="text-muted-foreground hover:text-foreground"
-			aria-label="Logout"
-		>
-			<LogOut className="h-5 w-5"/>
+		<Button variant="ghost" size="icon" onClick={logout} className="text-muted-foreground hover:text-foreground" aria-label="Logout">
+			<LogOut className="h-5 w-5" />
 		</Button>
 	);
 }

--- a/web/components/contexts/auth-context.tsx
+++ b/web/components/contexts/auth-context.tsx
@@ -1,102 +1,106 @@
-"use client"
+"use client";
 
-import {createContext, ReactNode, useContext, useEffect, useState} from "react"
-import {useRouter} from "next/navigation"
-import {extractJwtData} from "@/components/auth/jwt-decoder";
-import {refreshToken} from "@/components/api/user-api";
+import { createContext, ReactNode, useContext, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { extractJwtData } from "@/components/auth/jwt-decoder";
+import { refreshToken } from "@/components/api/user-api";
 
 interface AuthContextType {
-	token: string | null
-	user: string | null
-	isLoading: boolean
-	isAuthenticated: boolean
-	isExpired: boolean
-	expiration: Date | null
-	login: (token: string) => void
-	logout: () => void
+	token: string | null;
+	user: string | null;
+	isLoading: boolean;
+	isAuthenticated: boolean;
+	isExpired: boolean;
+	expiration: Date | null;
+	login: (token: string) => void;
+	logout: () => void;
 }
 
-const AuthContext = createContext<AuthContextType | undefined>(undefined)
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-export function AuthProvider({children}: { children: ReactNode }) {
-	const [token, setToken] = useState<string | null>(null)
-	const [user, setUser] = useState<string | null>(null)
-	const [isAuthenticated, setIsAuthenticated] = useState(false)
-	const [isExpired, setIsExpired] = useState(false)
-	const [expiration, setExpiration] = useState<Date | null>(null)
-	const router = useRouter()
+export function AuthProvider({ children }: { children: ReactNode }) {
+	const [token, setToken] = useState<string | null>(null);
+	const [user, setUser] = useState<string | null>(null);
+	const [isAuthenticated, setIsAuthenticated] = useState(false);
+	const [isExpired, setIsExpired] = useState(false);
+	const [expiration, setExpiration] = useState<Date | null>(null);
+	const router = useRouter();
 
-	const [isLoading, setLoading] = useState(true)
+	const [isLoading, setLoading] = useState(true);
 
 	// Load token from localStorage on initial render
 	useEffect(() => {
 		const checkAuth = () => {
-			const storedToken = localStorage.getItem("authToken")
+			const storedToken = localStorage.getItem("authToken");
 			if (!storedToken) {
-				logout()
+				logout();
 				setLoading(false);
 				return;
 			}
 
 			const decodedJwt = extractJwtData(storedToken);
 			if (!decodedJwt || decodedJwt.isExpired) {
-				logout()
+				logout();
 				setLoading(false);
 				return;
 			}
 
-			setToken(storedToken)
-			setUser(decodedJwt.username)
-			setIsExpired(decodedJwt.isExpired)
-			setExpiration(decodedJwt.expiration)
-			setIsAuthenticated(true)
+			setToken(storedToken);
+			setUser(decodedJwt.username);
+			setIsExpired(decodedJwt.isExpired);
+			setExpiration(decodedJwt.expiration);
+			setIsAuthenticated(true);
 
-			if (!decodedJwt.isExpired && decodedJwt.expiration && decodedJwt.expiration.getTime() - new Date().getTime() - (15 * 60 * 1000) <= 0) {
+			if (
+				!decodedJwt.isExpired &&
+				decodedJwt.expiration &&
+				decodedJwt.expiration.getTime() - new Date().getTime() - 15 * 60 * 1000 <= 0
+			) {
 				refreshToken(storedToken)
-					.then(response => {
+					.then((response) => {
 						if (response.status === 401) throw new Error("Invalid credentials");
 						if (response.error) throw new Error(response.error);
-						if (!response.data) throw new Error("Faulty response")
+						if (!response.data) throw new Error("Faulty response");
 						login(response.data.token);
-						console.debug("Token refreshed")
+						console.debug("Token refreshed");
 					})
-					.catch(error => {
+					.catch((error) => {
 						console.debug(error);
 					});
 			}
 
 			setLoading(false);
-		}
-		checkAuth()
-	}, [])
+		};
+		checkAuth();
+	}, []);
 
 	const login = (newToken: string) => {
-		localStorage.setItem("authToken", newToken)
-		setToken(newToken)
+		localStorage.setItem("authToken", newToken);
+		setToken(newToken);
 		const extracted = extractJwtData(newToken);
-		if (extracted) setUser(extracted.username)
-		setIsAuthenticated(true)
-	}
+		if (extracted) setUser(extracted.username);
+		setIsAuthenticated(true);
+	};
 
 	const logout = () => {
-		localStorage.removeItem("authToken")
-		setToken(null)
-		setUser(null)
-		setIsAuthenticated(false)
-		router.push("/login")
-	}
+		localStorage.removeItem("authToken");
+		setToken(null);
+		setUser(null);
+		setIsAuthenticated(false);
+		router.push("/login");
+	};
 
 	return (
-		<AuthContext.Provider value={{token, user, isAuthenticated, isLoading, isExpired, expiration, login, logout}}>
+		<AuthContext.Provider value={{ token, user, isAuthenticated, isLoading, isExpired, expiration, login, logout }}>
 			{children}
 		</AuthContext.Provider>
-	)
+	);
 }
 
 export function useAuth() {
-	const context = useContext(AuthContext)
+	const context = useContext(AuthContext);
 	if (context === undefined) {
-		throw new Error("useAuth must be used within an AuthProvider")
+		throw new Error("useAuth must be used within an AuthProvider");
 	}
-	return context
+	return context;
 }

--- a/web/components/contexts/route-accessibility.tsx
+++ b/web/components/contexts/route-accessibility.tsx
@@ -1,14 +1,14 @@
-"use client"
+"use client";
 
-import {usePathname, useRouter} from "next/navigation"
-import {useEffect} from "react"
-import {useAuth} from "@/components/contexts/auth-context";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { useAuth } from "@/components/contexts/auth-context";
 import LoadingPage from "@/components/loading-skeletons/loading-page";
 
-export function ProtectedRoute({children}: { children: React.ReactNode }) {
-	const {user, isAuthenticated, isLoading, isExpired} = useAuth()
-	const router = useRouter()
-	const currentPath = usePathname()
+export function ProtectedRoute({ children }: { children: React.ReactNode }) {
+	const { user, isAuthenticated, isLoading, isExpired } = useAuth();
+	const router = useRouter();
+	const currentPath = usePathname();
 
 	useEffect(() => {
 		console.debug(`User ${user} isAuthenticated: ${isAuthenticated}; isLoading ${isLoading}; isExpired: ${isExpired}`);
@@ -16,43 +16,41 @@ export function ProtectedRoute({children}: { children: React.ReactNode }) {
 			router.push("/login");
 			console.debug(`Redirected from ${currentPath} to /login`);
 		}
-	}, [user, isAuthenticated, isLoading, isExpired, router, currentPath])
+	}, [user, isAuthenticated, isLoading, isExpired, router, currentPath]);
 
-	if (isLoading || !isAuthenticated
-		|| (!isLoading && (!isAuthenticated || isExpired))) {
-		return <LoadingPage/>
+	if (isLoading || !isAuthenticated || (!isLoading && (!isAuthenticated || isExpired))) {
+		return <LoadingPage />;
 	}
 
-	return <>{children}</>
+	return <>{children}</>;
 }
 
-export function AnonymousAllowedRoute({children}: { children: React.ReactNode }) {
-	const {user, isAuthenticated, isLoading, isExpired} = useAuth()
-	const router = useRouter()
-	const currentPath = usePathname()
+export function AnonymousAllowedRoute({ children }: { children: React.ReactNode }) {
+	const { user, isAuthenticated, isLoading, isExpired } = useAuth();
+	const router = useRouter();
+	const currentPath = usePathname();
 
 	useEffect(() => {
 		console.debug(`User ${user} isAuthenticated: ${isAuthenticated}; isLoading ${isLoading}; isExpired: ${isExpired}`);
 		if (!isLoading && isAuthenticated && (currentPath == "/login" || currentPath == "/signup")) {
-			router.push(`/user/${user}`)
-			console.debug(`Redirected from /login to /user/${user}`)
+			router.push(`/user/${user}`);
+			console.debug(`Redirected from /login to /user/${user}`);
 		}
-	}, [user, isAuthenticated, isLoading, isExpired, router, currentPath])
+	}, [user, isAuthenticated, isLoading, isExpired, router, currentPath]);
 
-	if (isLoading
-		|| (!isLoading && isAuthenticated && (currentPath == "/login" || currentPath == "/signup"))) {
-		return <LoadingPage/>
+	if (isLoading || (!isLoading && isAuthenticated && (currentPath == "/login" || currentPath == "/signup"))) {
+		return <LoadingPage />;
 	}
 
-	return <>{children}</>
+	return <>{children}</>;
 }
 
-export function RestrictedRenderingRoute({children}: { children: React.ReactNode }) {
-	const pathname = usePathname()
+export function RestrictedRenderingRoute({ children }: { children: React.ReactNode }) {
+	const pathname = usePathname();
 
 	if (pathname === "/login" || pathname === "/signup") {
-		return null
+		return null;
 	}
 
-	return <>{children}</>
+	return <>{children}</>;
 }

--- a/web/components/data-providers/abstract-data-provider.tsx
+++ b/web/components/data-providers/abstract-data-provider.tsx
@@ -1,70 +1,65 @@
-import {DataProvider} from "@/components/data-providers/data-provider";
-import {Tier, TierlistEntry} from "@/components/model/types";
-import {fetchTiers} from "@/components/api/tier-api";
-import {fetchData, pullData, updateData} from "@/components/api/data-api";
-import {getDefaultTiers} from "@/components/model/defaults";
+import { DataProvider } from "@/components/data-providers/data-provider";
+import { Tier, TierlistEntry } from "@/components/model/types";
+import { fetchTiers } from "@/components/api/tier-api";
+import { fetchData, pullData, updateData } from "@/components/api/data-api";
+import { getDefaultTiers } from "@/components/model/defaults";
 
 export abstract class AbstractDataProvider implements DataProvider {
-
 	abstract getServiceName(): string;
 
 	abstract getTypeName(): string;
 
 	async fetchData(token: string | null, username: string, logout: () => void): Promise<TierlistEntry[]> {
-		return await fetchData(token, username, this.getServiceName(), this.getTypeName())
-			.then(response => {
-				if (response.status === 401 || response.status === 403) {
-					logout();
-					throw new Error("Session expired");
-				}
+		return await fetchData(token, username, this.getServiceName(), this.getTypeName()).then((response) => {
+			if (response.status === 401 || response.status === 403) {
+				logout();
+				throw new Error("Session expired");
+			}
 
-				if (response.status === 404) throw new Error("User not found or user doesn't have requested service connected");
-				if (response.error) throw new Error(`API error: ${response.status}`);
-				if (!response.data) throw new Error("Faulty response");
+			if (response.status === 404) throw new Error("User not found or user doesn't have requested service connected");
+			if (response.error) throw new Error(`API error: ${response.status}`);
+			if (!response.data) throw new Error("Faulty response");
 
-				return response.data;
-			});
+			return response.data;
+		});
 	}
 
 	async fetchTierlist(token: string | null, username: string, logout: () => void): Promise<Tier[]> {
-		return await fetchTiers(token, username, this.getServiceName(), this.getTypeName())
-			.then(response => {
-				if (response.status === 401 || response.status === 403) {
-					logout();
-					throw new Error("Session expired");
-				}
+		return await fetchTiers(token, username, this.getServiceName(), this.getTypeName()).then((response) => {
+			if (response.status === 401 || response.status === 403) {
+				logout();
+				throw new Error("Session expired");
+			}
 
-				if (response.status === 404) return getDefaultTiers();
-				if (response.error) throw new Error(`API error status: ${response.status}`);
-				if (!response.data) throw new Error("Faulty response");
+			if (response.status === 404) return getDefaultTiers();
+			if (response.error) throw new Error(`API error status: ${response.status}`);
+			if (!response.data) throw new Error("Faulty response");
 
-				return response.data;
-			});
+			return response.data;
+		});
 	}
 
 	async updateData(id: string, score: number, token: string | null, username: string, logout: () => void): Promise<void> {
-		return updateData(id, score, this.getServiceName(), this.getTypeName(), token, username)
-			.then(response => {
-				if (response.status === 401 || response.status === 403) {
-					logout()
-					throw new Error("Session expired or unauthorized");
-				}
-				if (response.status != 200) throw new Error(response.data ? response.data.message : `API error: ${response.status}`)
+		return updateData(id, score, this.getServiceName(), this.getTypeName(), token, username).then((response) => {
+			if (response.status === 401 || response.status === 403) {
+				logout();
+				throw new Error("Session expired or unauthorized");
+			}
+			if (response.status != 200) throw new Error(response.data ? response.data.message : `API error: ${response.status}`);
 
-				return;
-			});
+			return;
+		});
 	}
 
 	async pullData(token: string | null, username: string, logout: () => void): Promise<void> {
-		return pullData(token, username, this.getServiceName(), this.getTypeName())
-			.then(response => {
-				if (response.status === 401 || response.status === 403) {
-					logout();
-					throw new Error("Session expired");
-				}
-				if (response.status != 200) throw new Error(response.data ? response.data.message : `API error: ${response.status}`)
+		return pullData(token, username, this.getServiceName(), this.getTypeName()).then((response) => {
+			if (response.status === 401 || response.status === 403) {
+				logout();
+				throw new Error("Session expired");
+			}
+			if (response.status != 200) throw new Error(response.data ? response.data.message : `API error: ${response.status}`);
 
-				return;
-			});
+			return;
+		});
 	}
 }

--- a/web/components/data-providers/anilist/anilist-anime-data-provider.tsx
+++ b/web/components/data-providers/anilist/anilist-anime-data-provider.tsx
@@ -1,4 +1,4 @@
-import {AnilistDataProvider} from "@/components/data-providers/anilist/anilist-data-provider";
+import { AnilistDataProvider } from "@/components/data-providers/anilist/anilist-data-provider";
 
 export class AnilistAnimeProvider extends AnilistDataProvider {
 	getTypeName(): string {

--- a/web/components/data-providers/anilist/anilist-data-provider.tsx
+++ b/web/components/data-providers/anilist/anilist-data-provider.tsx
@@ -1,11 +1,9 @@
-import {AbstractDataProvider} from "@/components/data-providers/abstract-data-provider";
+import { AbstractDataProvider } from "@/components/data-providers/abstract-data-provider";
 
 export abstract class AnilistDataProvider extends AbstractDataProvider {
-
 	getServiceName(): string {
 		return "anilist";
 	}
 
 	abstract getTypeName(): string;
-
 }

--- a/web/components/data-providers/anilist/anilist-manga-data-provider.tsx
+++ b/web/components/data-providers/anilist/anilist-manga-data-provider.tsx
@@ -1,4 +1,4 @@
-import {AnilistDataProvider} from "@/components/data-providers/anilist/anilist-data-provider";
+import { AnilistDataProvider } from "@/components/data-providers/anilist/anilist-data-provider";
 
 export class AnilistMangaProvider extends AnilistDataProvider {
 	getTypeName(): string {

--- a/web/components/data-providers/data-provider.tsx
+++ b/web/components/data-providers/data-provider.tsx
@@ -1,26 +1,26 @@
-import {Tier, TierlistEntry} from "@/components/model/types";
-import {AnilistAnimeProvider} from "@/components/data-providers/anilist/anilist-anime-data-provider";
-import {AnilistMangaProvider} from "@/components/data-providers/anilist/anilist-manga-data-provider";
-import {TraktMoviesDataProvider} from "@/components/data-providers/trakt/trakt-movies-data-provider";
-import {TraktTvShowsDataProvider} from "@/components/data-providers/trakt/trakt-tv-shows-data-provider";
-import {TraktTvShowsSeasonsDataProvider} from "@/components/data-providers/trakt/trakt-tvshows-seasons-data-provider";
+import { TierlistEntry, Tier } from "@/components/model/types";
+import { AnilistAnimeProvider } from "@/components/data-providers/anilist/anilist-anime-data-provider";
+import { AnilistMangaProvider } from "@/components/data-providers/anilist/anilist-manga-data-provider";
+import { TraktMoviesDataProvider } from "@/components/data-providers/trakt/trakt-movies-data-provider";
+import { TraktTvShowsDataProvider } from "@/components/data-providers/trakt/trakt-tv-shows-data-provider";
+import { TraktTvShowsSeasonsDataProvider } from "@/components/data-providers/trakt/trakt-tvshows-seasons-data-provider";
 
 export interface DataProvider {
 	getServiceName: () => string;
 	getTypeName: () => string;
-	fetchData: (token: string | null, username: string, logout: () => void) => Promise<TierlistEntry[]>
-	fetchTierlist: (token: string | null, username: string, logout: () => void) => Promise<Tier[]>
-	updateData: (id: string, rating: number, token: string | null, username: string, logout: () => void) => Promise<void>
-	pullData: (token: string | null, username: string, logout: () => void) => Promise<void>
+	fetchData: (token: string | null, username: string, logout: () => void) => Promise<TierlistEntry[]>;
+	fetchTierlist: (token: string | null, username: string, logout: () => void) => Promise<Tier[]>;
+	updateData: (id: string, rating: number, token: string | null, username: string, logout: () => void) => Promise<void>;
+	pullData: (token: string | null, username: string, logout: () => void) => Promise<void>;
 }
 
 const providers: Record<string, DataProvider> = {
-	'anilist-anime': new AnilistAnimeProvider(),
-	'anilist-manga': new AnilistMangaProvider(),
-	'trakt-movies': new TraktMoviesDataProvider(),
-	'trakt-tvshows': new TraktTvShowsDataProvider(),
-	'trakt-tvshows-seasons': new TraktTvShowsSeasonsDataProvider(),
-}
+	"anilist-anime": new AnilistAnimeProvider(),
+	"anilist-manga": new AnilistMangaProvider(),
+	"trakt-movies": new TraktMoviesDataProvider(),
+	"trakt-tvshows": new TraktTvShowsDataProvider(),
+	"trakt-tvshows-seasons": new TraktTvShowsSeasonsDataProvider(),
+};
 
 export function getProviderByName(name: string): DataProvider {
 	const provider = providers[name];

--- a/web/components/data-providers/trakt/trakt-data-provider.tsx
+++ b/web/components/data-providers/trakt/trakt-data-provider.tsx
@@ -1,4 +1,4 @@
-import {AbstractDataProvider} from "@/components/data-providers/abstract-data-provider";
+import { AbstractDataProvider } from "@/components/data-providers/abstract-data-provider";
 
 export abstract class TraktDataProvider extends AbstractDataProvider {
 	getServiceName(): string {

--- a/web/components/data-providers/trakt/trakt-movies-data-provider.tsx
+++ b/web/components/data-providers/trakt/trakt-movies-data-provider.tsx
@@ -1,4 +1,4 @@
-import {TraktDataProvider} from "@/components/data-providers/trakt/trakt-data-provider";
+import { TraktDataProvider } from "@/components/data-providers/trakt/trakt-data-provider";
 
 export class TraktMoviesDataProvider extends TraktDataProvider {
 	getTypeName(): string {

--- a/web/components/data-providers/trakt/trakt-tv-shows-data-provider.tsx
+++ b/web/components/data-providers/trakt/trakt-tv-shows-data-provider.tsx
@@ -1,4 +1,4 @@
-import {TraktDataProvider} from "@/components/data-providers/trakt/trakt-data-provider";
+import { TraktDataProvider } from "@/components/data-providers/trakt/trakt-data-provider";
 
 export class TraktTvShowsDataProvider extends TraktDataProvider {
 	getTypeName(): string {

--- a/web/components/data-providers/trakt/trakt-tvshows-seasons-data-provider.tsx
+++ b/web/components/data-providers/trakt/trakt-tvshows-seasons-data-provider.tsx
@@ -1,4 +1,4 @@
-import {TraktDataProvider} from "@/components/data-providers/trakt/trakt-data-provider";
+import { TraktDataProvider } from "@/components/data-providers/trakt/trakt-data-provider";
 
 export class TraktTvShowsSeasonsDataProvider extends TraktDataProvider {
 	getTypeName(): string {

--- a/web/components/disclaimer/tmdb-disclaimer.tsx
+++ b/web/components/disclaimer/tmdb-disclaimer.tsx
@@ -3,9 +3,9 @@ import Image from "next/image";
 export default function TmdbDisclaimer() {
 	return (
 		<div className={"flex gap-1 justify-center"}>
-			<Image src={"/tmdb.svg"} alt={"tmdb logo"} width={26} height={26}/>
+			<Image src={"/tmdb.svg"} alt={"tmdb logo"} width={26} height={26} />
 			Images provided by
 			<a href={"https://themoviedb.org"}>themoviedb.org</a>
 		</div>
-	)
+	);
 }

--- a/web/components/loading-skeletons/loading-page.tsx
+++ b/web/components/loading-skeletons/loading-page.tsx
@@ -5,5 +5,5 @@ export default function LoadingPage() {
 		<div className="flex items-center justify-center min-h-screen">
 			<div className="animate-pulse text-muted-foreground">Loading...</div>
 		</div>
-	)
+	);
 }

--- a/web/components/loading-skeletons/tier-config-table-skeleton.tsx
+++ b/web/components/loading-skeletons/tier-config-table-skeleton.tsx
@@ -1,20 +1,20 @@
-import {Skeleton} from "@/components/ui/skeleton";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export function TierConfigTableSkeleton() {
-	return Array(5).fill(0).map((_, index) => (
-		<div
-			key={`skeleton-${index}`}
-			className="grid grid-cols-[60px_1fr_100px_120px_40px] gap-4 items-center"
-		>
-			{Array(4).fill(0).map((_, index2) => (
-				// eslint-disable-next-line react/jsx-key
-				<div key={`skeleton-${index}-${index2}`}>
-					<Skeleton className="h-9 w-full"/>
+	return Array(5)
+		.fill(0)
+		.map((_, index) => (
+			<div key={`skeleton-${index}`} className="grid grid-cols-[60px_1fr_100px_120px_40px] gap-4 items-center">
+				{Array(4)
+					.fill(0)
+					.map((_, index2) => (
+						<div key={`skeleton-${index}-${index2}`}>
+							<Skeleton className="h-9 w-full" />
+						</div>
+					))}
+				<div>
+					<Skeleton className="h-9 w-9" />
 				</div>
-			))}
-			<div>
-				<Skeleton className="h-9 w-9"/>
 			</div>
-		</div>
-	));
+		));
 }

--- a/web/components/loading-skeletons/tier-container-skeleton.tsx
+++ b/web/components/loading-skeletons/tier-container-skeleton.tsx
@@ -1,32 +1,42 @@
-import {Skeleton} from "@/components/ui/skeleton";
-import {cn} from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 
 export function TierContainerSkeleton() {
-	return Array(6).fill(0).map((_, index) => (
-		<div key={`skeleton-${index}`}
-			 className="grid grid-cols-[auto_1fr] rounded-md overflow-hidden border border-border/60 h-[160px] mb-1">
-			<Skeleton className={"w-16 rounded-l-md rounded-r-none"}/>
-			<Skeleton className={"w-full rounded-r-md rounded-l-none"}/>
-		</div>
-	));
+	return Array(6)
+		.fill(0)
+		.map((_, index) => (
+			<div
+				key={`skeleton-${index}`}
+				className="grid grid-cols-[auto_1fr] rounded-md overflow-hidden border border-border/60 h-[160px] mb-1"
+			>
+				<Skeleton className={"w-16 rounded-l-md rounded-r-none"} />
+				<Skeleton className={"w-full rounded-r-md rounded-l-none"} />
+			</div>
+		));
 }
 
-export function TierlistEntrySkeleton({color, label}: { color: string, label: string }) {
+export function TierlistEntrySkeleton({ color, label }: { color: string; label: string }) {
 	return (
-		<div className={cn("grid grid-cols-[auto_1fr] mb-1",
-			"overflow-hidden border border-border/60 rounded-2xl bg-card/60 backdrop-blur-sm",)}
+		<div
+			className={cn(
+				"grid grid-cols-[auto_1fr] mb-1",
+				"overflow-hidden border border-border/60 rounded-2xl bg-card/60 backdrop-blur-sm"
+			)}
 		>
-			<div style={{backgroundColor: `${color}`}}
-				 className={"flex items-center justify-center w-16 self-stretch text-white font-bold text-xl"}>
+			<div
+				style={{ backgroundColor: `${color}` }}
+				className={"flex items-center justify-center w-16 self-stretch text-white font-bold text-xl"}
+			>
 				{label}
 			</div>
 			<div className="flex-1 min-h-16 bg-background/50 p-2 flex flex-wrap gap-2 transition-colors">
-				{Array(Math.floor(Math.random() * (7) + 2)).fill(0).map((_, index) => (
-					<div key={`skeleton-tierlist-entry-${index}`}>
-						<Skeleton
-							className="w-20 h-36 bg-card border border-border/40 rounded-md shadow-sm cursor-move flex flex-col items-center justify-center transition-opacity"></Skeleton>
-					</div>
-				))}
+				{Array(Math.floor(Math.random() * 7 + 2))
+					.fill(0)
+					.map((_, index) => (
+						<div key={`skeleton-tierlist-entry-${index}`}>
+							<Skeleton className="w-20 h-36 bg-card border border-border/40 rounded-md shadow-sm cursor-move flex flex-col items-center justify-center transition-opacity"></Skeleton>
+						</div>
+					))}
 			</div>
 		</div>
 	);

--- a/web/components/model/defaults.tsx
+++ b/web/components/model/defaults.tsx
@@ -1,4 +1,4 @@
-import {Tier} from "@/components/model/types"; // Make sure to install this package: npm install uuid
+import { Tier } from "@/components/model/types"; // Make sure to install this package: npm install uuid
 
 export function getDefaultTiers(): Tier[] {
 	return [
@@ -7,77 +7,77 @@ export function getDefaultTiers(): Tier[] {
 			name: "S",
 			score: 10.0,
 			adjustedScore: 10.0,
-			color: "#FF7F7F"
+			color: "#FF7F7F",
 		},
 		{
 			id: crypto.randomUUID(),
 			name: "A+",
 			score: 9.0,
 			adjustedScore: 9.0,
-			color: "#FF9E7F"
+			color: "#FF9E7F",
 		},
 		{
 			id: crypto.randomUUID(),
 			name: "A",
 			score: 8.0,
 			adjustedScore: 8.0,
-			color: "#FFBF7F"
+			color: "#FFBF7F",
 		},
 		{
 			id: crypto.randomUUID(),
 			name: "B+",
 			score: 7.0,
 			adjustedScore: 7.0,
-			color: "#e4e449"
+			color: "#e4e449",
 		},
 		{
 			id: crypto.randomUUID(),
 			name: "B",
 			score: 6.0,
 			adjustedScore: 6.0,
-			color: "#aae371"
+			color: "#aae371",
 		},
 		{
 			id: crypto.randomUUID(),
 			name: "C+",
 			score: 5.0,
 			adjustedScore: 5.0,
-			color: "#7FDFBF"
+			color: "#7FDFBF",
 		},
 		{
 			id: crypto.randomUUID(),
 			name: "C",
 			score: 4.0,
 			adjustedScore: 4.0,
-			color: "#7FBFFF"
+			color: "#7FBFFF",
 		},
 		{
 			id: crypto.randomUUID(),
 			name: "D",
 			score: 3.0,
 			adjustedScore: 3.0,
-			color: "#9F7FFF"
+			color: "#9F7FFF",
 		},
 		{
 			id: crypto.randomUUID(),
 			name: "E",
 			score: 2.0,
 			adjustedScore: 2.0,
-			color: "#BF7FFF"
+			color: "#BF7FFF",
 		},
 		{
 			id: crypto.randomUUID(),
 			name: "F",
 			score: 1.0,
 			adjustedScore: 1.0,
-			color: "#FF7FBF"
+			color: "#FF7FBF",
 		},
 		{
 			id: crypto.randomUUID(),
 			name: "-",
 			score: 0.0,
 			adjustedScore: 0.0,
-			color: "#E6E6FF"
-		}
+			color: "#E6E6FF",
+		},
 	];
 }

--- a/web/components/model/response-types.tsx
+++ b/web/components/model/response-types.tsx
@@ -26,7 +26,7 @@ export interface UserResponse {
 }
 
 export interface ThirdPartyAuthResponse {
-	message: string
+	message: string;
 }
 
 export interface ThirdPartyInfoResponse {

--- a/web/components/model/types.tsx
+++ b/web/components/model/types.tsx
@@ -1,10 +1,10 @@
 export interface TierlistEntry {
-	id: string
-	score: number
-	title: string
-	cover: string
-	tier: Tier
-	index: number
+	id: string;
+	score: number;
+	title: string;
+	cover: string;
+	tier: Tier;
+	index: number;
 }
 
 export interface Tier {

--- a/web/components/navbar/navbar-links.tsx
+++ b/web/components/navbar/navbar-links.tsx
@@ -1,14 +1,14 @@
-"use client"
+"use client";
 
-import {Button} from "@/components/ui/button";
-import {cn} from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import Link from "next/link";
-import {useAuth} from "@/components/contexts/auth-context";
-import {usePathname} from "next/navigation";
+import { useAuth } from "@/components/contexts/auth-context";
+import { usePathname } from "next/navigation";
 
 export default function NavbarLinks() {
-	const {user} = useAuth()
-	const pathname = usePathname()
+	const { user } = useAuth();
+	const pathname = usePathname();
 
 	return (
 		<div className="flex items-center space-x-1 ml-6">
@@ -26,10 +26,7 @@ export default function NavbarLinks() {
 			<Button
 				variant="ghost"
 				asChild
-				className={cn(
-					"px-3 text-sm font-medium",
-					pathname.startsWith("/user/") ? "text-foreground" : "text-muted-foreground"
-				)}
+				className={cn("px-3 text-sm font-medium", pathname.startsWith("/user/") ? "text-foreground" : "text-muted-foreground")}
 			>
 				<Link href={`/user/${user}`}>Profile</Link>
 			</Button>

--- a/web/components/navbar/navbar.tsx
+++ b/web/components/navbar/navbar.tsx
@@ -1,21 +1,22 @@
-import Link from "next/link"
-import {cn} from "@/lib/utils"
+import Link from "next/link";
+import { cn } from "@/lib/utils";
 import ThemeToggle from "@/components/themes/theme-toggle";
 import LogoutButton from "@/components/auth/logout-button";
 import NavbarLinks from "@/components/navbar/navbar-links";
-import {RestrictedRenderingRoute} from "@/components/contexts/route-accessibility";
+import { RestrictedRenderingRoute } from "@/components/contexts/route-accessibility";
 import SettingsButton from "@/components/navbar/settings-button";
 
 export default function NavBar() {
-
 	return (
 		<RestrictedRenderingRoute>
 			<div className="fixed top-0 left-0 right-0 z-50 flex justify-center px-4 py-4 pointer-events-none">
-				<nav className={cn(
-					"flex h-14 w-full max-w-[1600px] flex-row items-center px-4 lg:px-6 rounded-2xl",
-					"bg-card/60 backdrop-blur-sm border border-border/100 shadow-lg",
-					"pointer-events-auto"
-				)}>
+				<nav
+					className={cn(
+						"flex h-14 w-full max-w-[1600px] flex-row items-center px-4 lg:px-6 rounded-2xl",
+						"bg-card/60 backdrop-blur-sm border border-border/100 shadow-lg",
+						"pointer-events-auto"
+					)}
+				>
 					<Link href="/user" className="inline-flex items-center gap-2 font-semibold">
 						<div className="flex items-center gap-1.5">
 							<svg
@@ -30,26 +31,26 @@ export default function NavBar() {
 								strokeLinejoin="round"
 								className="text-primary"
 							>
-								<path d="M2 20h20"/>
-								<path d="M5 14h14"/>
-								<path d="M8 8h8"/>
-								<path d="M11 2h2"/>
+								<path d="M2 20h20" />
+								<path d="M5 14h14" />
+								<path d="M8 8h8" />
+								<path d="M11 2h2" />
 							</svg>
 							<span className="text-xl font-medium max-sm:hidden">TierRating</span>
 						</div>
 					</Link>
 
-					<NavbarLinks/>
+					<NavbarLinks />
 
 					<div className="flex flex-1 items-center justify-end gap-2">
 						{/*<SearchBar/>*/}
 
-						<ThemeToggle/>
-						<SettingsButton/>
-						<LogoutButton/>
+						<ThemeToggle />
+						<SettingsButton />
+						<LogoutButton />
 					</div>
 				</nav>
 			</div>
 		</RestrictedRenderingRoute>
-	)
+	);
 }

--- a/web/components/navbar/search-bar.tsx
+++ b/web/components/navbar/search-bar.tsx
@@ -1,16 +1,16 @@
-import {Button} from "@/components/ui/button";
-import {Search} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Search } from "lucide-react";
 
 export default function SearchBar() {
 	return (
 		<div className="relative max-w-[240px] w-full max-lg:hidden">
 			<Button
 				variant="outline"
-				onClick={() => window.location.href = "/search"}
+				onClick={() => (window.location.href = "/search")}
 				className="flex w-full items-center justify-between rounded-full border bg-background/50 px-3 py-1.5 text-sm text-muted-foreground shadow-none hover:bg-accent"
 			>
 				<div className="flex items-center gap-2">
-					<Search className="h-4 w-4"/>
+					<Search className="h-4 w-4" />
 					<span>Search</span>
 				</div>
 				<div className="flex items-center gap-1">

--- a/web/components/navbar/settings-button.tsx
+++ b/web/components/navbar/settings-button.tsx
@@ -1,17 +1,12 @@
-import {Button} from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import {Settings} from "lucide-react";
+import { Settings } from "lucide-react";
 
 export default function SettingsButton() {
 	return (
-		<Button
-			variant="ghost"
-			size="icon"
-			className="text-muted-foreground hover:text-foreground"
-			aria-label="Settings"
-		>
+		<Button variant="ghost" size="icon" className="text-muted-foreground hover:text-foreground" aria-label="Settings">
 			<Link href={"/settings"}>
-				<Settings className="h-5 w-5"/>
+				<Settings className="h-5 w-5" />
 			</Link>
 		</Button>
 	);

--- a/web/components/themes/theme-provider.tsx
+++ b/web/components/themes/theme-provider.tsx
@@ -1,11 +1,8 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import {ThemeProvider as NextThemesProvider} from "next-themes"
+import * as React from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
 
-export function ThemeProvider({
-								  children,
-								  ...props
-							  }: React.ComponentProps<typeof NextThemesProvider>) {
-	return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+export function ThemeProvider({ children, ...props }: React.ComponentProps<typeof NextThemesProvider>) {
+	return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
 }

--- a/web/components/themes/theme-toggle.tsx
+++ b/web/components/themes/theme-toggle.tsx
@@ -1,34 +1,25 @@
-"use client"
+"use client";
 
-import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from "@/components/ui/dropdown-menu";
-import {Button} from "@/components/ui/button";
-import {Moon, Sun} from "lucide-react";
-import {useTheme} from "next-themes";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
 
 export default function ThemeToggle() {
-	const {setTheme} = useTheme()
+	const { setTheme } = useTheme();
 
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
-				<Button variant="outline" size="icon"
-						className="rounded-full border h-9 w-9 p-0 max-lg:hidden">
-					<Sun
-						className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90"/>
-					<Moon
-						className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0"/>
+				<Button variant="outline" size="icon" className="rounded-full border h-9 w-9 p-0 max-lg:hidden">
+					<Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+					<Moon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end">
-				<DropdownMenuItem onClick={() => setTheme("light")}>
-					Light
-				</DropdownMenuItem>
-				<DropdownMenuItem onClick={() => setTheme("dark")}>
-					Dark
-				</DropdownMenuItem>
-				<DropdownMenuItem onClick={() => setTheme("system")}>
-					System
-				</DropdownMenuItem>
+				<DropdownMenuItem onClick={() => setTheme("light")}>Light</DropdownMenuItem>
+				<DropdownMenuItem onClick={() => setTheme("dark")}>Dark</DropdownMenuItem>
+				<DropdownMenuItem onClick={() => setTheme("system")}>System</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/web/components/tierlist/tier-container-droppable.tsx
+++ b/web/components/tierlist/tier-container-droppable.tsx
@@ -1,36 +1,42 @@
-import {useDroppable} from "@dnd-kit/react";
+import { useDroppable } from "@dnd-kit/react";
 import React from "react";
-import {cn} from "@/lib/utils";
+import { cn } from "@/lib/utils";
 
-export default function TierContainerDroppable({children, id, label, color, disabled}: {
-	children: React.ReactNode,
-	id: string,
-	label: string,
-	color: string,
-	disabled: boolean
+export default function TierContainerDroppable({
+	children,
+	id,
+	label,
+	color,
+	disabled,
+}: {
+	children: React.ReactNode;
+	id: string;
+	label: string;
+	color: string;
+	disabled: boolean;
 }) {
-	const {ref, isDropTarget} = useDroppable({
+	const { ref, isDropTarget } = useDroppable({
 		id: id,
-		disabled: disabled
+		disabled: disabled,
 	});
 
 	return (
 		<div
 			ref={ref}
-			className={cn("grid grid-cols-[auto_1fr] mb-1",
+			className={cn(
+				"grid grid-cols-[auto_1fr] mb-1",
 				"overflow-hidden border border-border/60 rounded-2xl bg-card/60 backdrop-blur-sm",
-				isDropTarget ? `ring-2 ring-accent` : "")}
-			style={{minHeight: "80px"}}
+				isDropTarget ? `ring-2 ring-accent` : ""
+			)}
+			style={{ minHeight: "80px" }}
 		>
 			<div
 				className={"flex items-center justify-center w-16 text-shadow-white font-bold text-xl line-clamp-1 truncate"}
-				style={{backgroundColor: `${color}`}}
+				style={{ backgroundColor: `${color}` }}
 			>
 				{label}
 			</div>
-			<div className={"min-h-16 bg-background/50 p-2 flex flex-wrap gap-2"}>
-				{children}
-			</div>
+			<div className={"min-h-16 bg-background/50 p-2 flex flex-wrap gap-2"}>{children}</div>
 		</div>
-	)
+	);
 }

--- a/web/components/tierlist/tier-list-page.tsx
+++ b/web/components/tierlist/tier-list-page.tsx
@@ -1,50 +1,50 @@
-"use client"
+"use client";
 
 import TierList from "@/components/tierlist/tier-list";
 import TmdbDisclaimer from "@/components/disclaimer/tmdb-disclaimer";
-import {useState} from "react";
-import {Toggle} from "@/components/ui/toggle";
-import {ArrowLeftFromLine, ArrowRightFromLine} from "lucide-react";
-import {cn} from "@/lib/utils";
-import {ButtonGroup} from "@/components/ui/button-group";
-import {Button} from "@/components/ui/button";
-import {getProviderByName} from "@/components/data-providers/data-provider";
-import {useAuth} from "@/components/contexts/auth-context";
-import {useParams} from "next/navigation";
+import { useState } from "react";
+import { Toggle } from "@/components/ui/toggle";
+import { ArrowLeftFromLine, ArrowRightFromLine } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ButtonGroup } from "@/components/ui/button-group";
+import { Button } from "@/components/ui/button";
+import { getProviderByName } from "@/components/data-providers/data-provider";
+import { useAuth } from "@/components/contexts/auth-context";
+import { useParams } from "next/navigation";
 
-export default function TierListPage({title, provider}: { title: string, provider: string }) {
+export default function TierListPage({ title, provider }: { title: string; provider: string }) {
 	const [isFullWidth, setIsFullWidth] = useState<boolean>(false);
-	const {token, user, logout} = useAuth();
+	const { token, user, logout } = useAuth();
 	const username: string = useParams<{ username: string }>().username;
 	const modificationAllowed: boolean = user == username;
 
 	return (
-		<div className={cn("max-w-full mx-auto content-center px-4",
-			"transition-all duration-400 ease-in-out",
-			isFullWidth ? "w-full" : "w-[1514px] ")}>
+		<div
+			className={cn(
+				"max-w-full mx-auto content-center px-4",
+				"transition-all duration-400 ease-in-out",
+				isFullWidth ? "w-full" : "w-[1514px] "
+			)}
+		>
 			<div className={"grid grid-cols-2"}>
 				<h1 className="text-3xl font-bold mb-6">{title}</h1>
 				<div className={"w-full flex justify-end items-end pb-2"}>
 					<ButtonGroup>
-						{modificationAllowed &&
-                            <Button variant={"ghost"}
-                                    onClick={() => getProviderByName(provider).pullData(token, username, logout)}>
-                                Pull
-                            </Button>
-						}
-						<Toggle
-							aria-label={"Toggle full width"}
-							onPressedChange={() => setIsFullWidth(!isFullWidth)}
-						>
-							<ArrowLeftFromLine/>
+						{modificationAllowed && (
+							<Button variant={"ghost"} onClick={() => getProviderByName(provider).pullData(token, username, logout)}>
+								Pull
+							</Button>
+						)}
+						<Toggle aria-label={"Toggle full width"} onPressedChange={() => setIsFullWidth(!isFullWidth)}>
+							<ArrowLeftFromLine />
 							Full Width
-							<ArrowRightFromLine/>
+							<ArrowRightFromLine />
 						</Toggle>
 					</ButtonGroup>
 				</div>
 			</div>
-			<TierList providerName={provider}/>
-			{provider.startsWith("trakt") && <TmdbDisclaimer/>}
+			<TierList providerName={provider} />
+			{provider.startsWith("trakt") && <TmdbDisclaimer />}
 		</div>
-	)
+	);
 }

--- a/web/components/tierlist/tier-list.tsx
+++ b/web/components/tierlist/tier-list.tsx
@@ -1,19 +1,18 @@
-"use client"
+"use client";
 
-import React, {useEffect, useState} from "react";
-import {Tier, TierlistEntry} from "@/components/model/types";
-import {getDefaultTiers} from "@/components/model/defaults";
-import {useAuth} from "@/components/contexts/auth-context";
-import {useParams} from "next/navigation";
-import {getProviderByName} from "@/components/data-providers/data-provider";
-import {TierContainerSkeleton, TierlistEntrySkeleton} from "@/components/loading-skeletons/tier-container-skeleton";
-import {TierlistEntryCard, TierlistEntryDraggable} from "@/components/tierlist/tierlist-entry-draggable";
-import {DragDropProvider, DragOverlay} from "@dnd-kit/react";
-import {assignTiersAndGroupEntriesByTier, groupBySingle, sortByName} from "@/components/tierlist/tier-mapper";
+import React, { useEffect, useState } from "react";
+import { Tier, TierlistEntry } from "@/components/model/types";
+import { getDefaultTiers } from "@/components/model/defaults";
+import { useAuth } from "@/components/contexts/auth-context";
+import { useParams } from "next/navigation";
+import { getProviderByName } from "@/components/data-providers/data-provider";
+import { TierContainerSkeleton, TierlistEntrySkeleton } from "@/components/loading-skeletons/tier-container-skeleton";
+import { TierlistEntryDraggable, TierlistEntryCard } from "@/components/tierlist/tierlist-entry-draggable";
+import { DragDropProvider, DragOverlay } from "@dnd-kit/react";
+import { assignTiersAndGroupEntriesByTier, groupBySingle, sortByName } from "@/components/tierlist/tier-mapper";
 import TierContainerDroppable from "@/components/tierlist/tier-container-droppable";
 
-
-export default function TierList({providerName}: { providerName: string }) {
+export default function TierList({ providerName }: { providerName: string }) {
 	const [tiers, setTiers] = useState<Tier[]>([]);
 	const [entries, setEntries] = useState<TierlistEntry[]>([]);
 
@@ -22,7 +21,7 @@ export default function TierList({providerName}: { providerName: string }) {
 	const [tiersById, setTiersById] = useState<Map<string, Tier>>(new Map());
 	const [tiersByName, setTiersByName] = useState<Map<string, Tier>>(new Map());
 
-	const {user, token, isLoading, isAuthenticated, logout} = useAuth();
+	const { user, token, isLoading, isAuthenticated, logout } = useAuth();
 	const username: string = useParams<{ username: string }>().username;
 	const dndDisabled: boolean = user != username;
 
@@ -35,7 +34,8 @@ export default function TierList({providerName}: { providerName: string }) {
 	// fetch tiers
 	useEffect(() => {
 		if (!isLoading && isAuthenticated && provider) {
-			provider.fetchTierlist(token, username, logout)
+			provider
+				.fetchTierlist(token, username, logout)
 				.then((data: Tier[]) => setTiers(data && data.length > 0 ? data : getDefaultTiers()))
 				.catch((error) => console.error(error))
 				.finally(() => setTiersQueryRunning(false));
@@ -45,7 +45,8 @@ export default function TierList({providerName}: { providerName: string }) {
 	// fetch entries
 	useEffect(() => {
 		if (!isLoading && isAuthenticated && provider) {
-			provider.fetchData(token, username, logout)
+			provider
+				.fetchData(token, username, logout)
 				.then((data: TierlistEntry[]) => setEntries(data))
 				.catch((error) => console.error(error))
 				.finally(() => setEntriesQueryRunning(false));
@@ -55,24 +56,24 @@ export default function TierList({providerName}: { providerName: string }) {
 	// perform mapping
 	useEffect(() => {
 		if (!tiersQueryRunning && !entriesQueryRunning && !mappingCompleted) {
-			const entriesByTier = assignTiersAndGroupEntriesByTier(tiers, entries)
+			const entriesByTier = assignTiersAndGroupEntriesByTier(tiers, entries);
 			setEntriesByTierId(entriesByTier);
-			setEntriesById(groupBySingle(entries, entry => entry.id));
-			setTiersById(groupBySingle(tiers, tier => tier.id));
-			setTiersByName(groupBySingle(tiers, tier => tier.name));
-			setMappingCompleted(true)
+			setEntriesById(groupBySingle(entries, (entry) => entry.id));
+			setTiersById(groupBySingle(tiers, (tier) => tier.id));
+			setTiersByName(groupBySingle(tiers, (tier) => tier.name));
+			setMappingCompleted(true);
 		}
-	}, [tiers, entries, tiersQueryRunning, entriesQueryRunning, mappingCompleted])
+	}, [tiers, entries, tiersQueryRunning, entriesQueryRunning, mappingCompleted]);
 
-	const onDragEnd = async (event: { canceled: any; operation: { source: any; target: any; }; }) => {
+	const onDragEnd = async (event: { canceled: any; operation: { source: any; target: any } }) => {
 		if (event.canceled) return;
 
 		if (!entriesByTierId || !tiersById || !tiersByName || !entriesById) {
-			console.error("Something went wrong while mapping. Refresh page")
+			console.error("Something went wrong while mapping. Refresh page");
 			return;
 		}
 
-		const {source, target} = event.operation;
+		const { source, target } = event.operation;
 		const targetTier = tiersById.get(target.id);
 		const entryToChange = entriesById.get(source.id);
 		const currentTier = entryToChange?.tier;
@@ -85,62 +86,64 @@ export default function TierList({providerName}: { providerName: string }) {
 		// This kinda works for processing changes in the background, but this can only be spawned once.
 		// As soon as a second action is triggered, it is blocked again, until the first one has completed
 		setTimeout(() => {
-			provider.updateData(entryToChange.id, targetTier.adjustedScore, token, username, logout)
+			provider
+				.updateData(entryToChange.id, targetTier.adjustedScore, token, username, logout)
 				.then(() => {
-					console.debug("Committed changes to third-party service")
+					console.debug("Committed changes to third-party service");
 				})
-				.catch(error => {
+				.catch((error) => {
 					console.error(error);
 					updateEntry(entryToChange, currentTier!);
-				})
+				});
 		}, 200);
-	}
+	};
 
 	const updateEntry = (entryToChange: TierlistEntry, targetTier: Tier) => {
-		console.debug(`${entryToChange.title}: ${entryToChange.tier.name} -> ${targetTier.name}`)
+		console.debug(`${entryToChange.title}: ${entryToChange.tier.name} -> ${targetTier.name}`);
 
 		const prevTier = entryToChange.tier;
 
-		entryToChange.tier = targetTier
-		entryToChange.score = targetTier?.adjustedScore
+		entryToChange.tier = targetTier;
+		entryToChange.score = targetTier?.adjustedScore;
 
 		// add entryToChange to new tier
-		entriesByTierId.set(targetTier.id, [...entriesByTierId.get(targetTier.id)!, entryToChange].sort(sortByName))
+		entriesByTierId.set(targetTier.id, [...entriesByTierId.get(targetTier.id)!, entryToChange].sort(sortByName));
 		// remove entryToChange from its current tier
-		setEntriesByTierId(prevMap => {
+		setEntriesByTierId((prevMap) => {
 			const currentEntries = prevMap.get(prevTier.id)!;
 			const newMap = new Map(prevMap);
-			const updatedEntries = currentEntries.filter(entry => entry.id !== entryToChange.id);
+			const updatedEntries = currentEntries.filter((entry) => entry.id !== entryToChange.id);
 			newMap.set(prevTier.id, updatedEntries);
 			return newMap;
-		})
-	}
+		});
+	};
 
 	if (tiersQueryRunning) {
-		return <TierContainerSkeleton/>
+		return <TierContainerSkeleton />;
 	}
 
 	if (entriesQueryRunning || !mappingCompleted) {
-		return tiers.map((tier) => (<TierlistEntrySkeleton key={tier.id} color={tier.color} label={tier.name}/>));
+		return tiers.map((tier) => <TierlistEntrySkeleton key={tier.id} color={tier.color} label={tier.name} />);
 	}
 
 	return (
 		<DragDropProvider onDragEnd={onDragEnd}>
 			{Array.from(entriesByTierId.keys())
-				.map(tierId => tiersById.get(tierId))
-				.map(tier => (
-					tier &&
-                    <TierContainerDroppable key={tier.id} id={tier.id} label={tier.name} color={tier.color}
-                                            disabled={dndDisabled}>
-						{Array.from(entriesByTierId.get(tier.id)!).map(entry => (
-							<TierlistEntryDraggable key={entry.id} entry={entry} disabled={dndDisabled}/>
-						))}
-                    </TierContainerDroppable>
-				))}
+				.map((tierId) => tiersById.get(tierId))
+				.map(
+					(tier) =>
+						tier && (
+							<TierContainerDroppable key={tier.id} id={tier.id} label={tier.name} color={tier.color} disabled={dndDisabled}>
+								{Array.from(entriesByTierId.get(tier.id)!).map((entry) => (
+									<TierlistEntryDraggable key={entry.id} entry={entry} disabled={dndDisabled} />
+								))}
+							</TierContainerDroppable>
+						)
+				)}
 			<DragOverlay>
 				{(source) => (
-					// @ts-ignore
-					<TierlistEntryCard key={source.id} entry={source.data}/>
+					// @ts-expect-error - Type mismatch in drag overlay source data
+					<TierlistEntryCard key={source.id} entry={source.data} />
 				)}
 			</DragOverlay>
 		</DragDropProvider>

--- a/web/components/tierlist/tier-mapper.tsx
+++ b/web/components/tierlist/tier-mapper.tsx
@@ -1,4 +1,4 @@
-import {Tier, TierlistEntry} from "@/components/model/types";
+import { Tier, TierlistEntry } from "@/components/model/types";
 
 export function assignTiersAndGroupEntriesByTier(tiers: Tier[], items: TierlistEntry[]): Map<string, TierlistEntry[]> {
 	// Proper order (sorted descending by score) is assured by the server
@@ -7,7 +7,7 @@ export function assignTiersAndGroupEntriesByTier(tiers: Tier[], items: TierlistE
 	let positionIndex = 0;
 
 	const entriesByTier = new Map<string, TierlistEntry[]>();
-	tiers.forEach(tier => entriesByTier.set(tier.id, []))
+	tiers.forEach((tier) => entriesByTier.set(tier.id, []));
 
 	while (itemsIndex < items.length && tiersIndex < tiers.length) {
 		if (items[itemsIndex].score >= tiers[tiersIndex].score) {
@@ -27,19 +27,19 @@ export function assignTiersAndGroupEntriesByTier(tiers: Tier[], items: TierlistE
 		}
 	}
 
-	entriesByTier.keys().forEach(key => entriesByTier.set(key, entriesByTier.get(key)!.sort(sortByName)))
+	Array.from(entriesByTier.keys()).forEach((key) => entriesByTier.set(key, entriesByTier.get(key)!.sort(sortByName)));
 
 	return entriesByTier;
 }
 
 export function groupBySingle<T, K>(arr: T[], key: (i: T) => K): Map<K, T> {
 	const map = new Map<K, T>();
-	arr.forEach(elem => map.set(key(elem), elem));
+	arr.forEach((elem) => map.set(key(elem), elem));
 	return map;
 }
 
 export function sortByName(a: TierlistEntry, b: TierlistEntry) {
 	const textA = a.title.toLowerCase();
 	const textB = b.title.toLowerCase();
-	return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;
+	return textA < textB ? -1 : textA > textB ? 1 : 0;
 }

--- a/web/components/tierlist/tierlist-entry-draggable.tsx
+++ b/web/components/tierlist/tierlist-entry-draggable.tsx
@@ -1,51 +1,40 @@
-import {TierlistEntry} from "@/components/model/types";
-import {cn} from "@/lib/utils";
+import { TierlistEntry } from "@/components/model/types";
+import { cn } from "@/lib/utils";
 import Image from "next/image";
-import {useDraggable} from "@dnd-kit/react";
-import {HoverCard, HoverCardContent, HoverCardTrigger} from "@/components/ui/hover-card";
+import { useDraggable } from "@dnd-kit/react";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 
-export function TierlistEntryDraggable({entry, disabled}: { entry: TierlistEntry, disabled: boolean }) {
-	const {ref} = useDraggable({
+export function TierlistEntryDraggable({ entry, disabled }: { entry: TierlistEntry; disabled: boolean }) {
+	const { ref } = useDraggable({
 		id: entry.id,
 		data: entry,
-		disabled: disabled
+		disabled: disabled,
 	});
 
 	return (
 		<div ref={ref}>
-			<TierlistEntryCard entry={entry}/>
+			<TierlistEntryCard entry={entry} />
 		</div>
-	)
+	);
 }
 
-export function TierlistEntryCard({entry}: { entry: TierlistEntry }) {
+export function TierlistEntryCard({ entry }: { entry: TierlistEntry }) {
 	return (
 		<div
 			className={cn(
 				"w-20 h-36 flex flex-col items-center justify-center",
-				"bg-card border border-border/40 rounded-md shadow-sm cursor-move",
+				"bg-card border border-border/40 rounded-md shadow-sm cursor-move"
 			)}
 		>
 			<div className="relative w-full h-full">
-				<Image
-					src={entry.cover}
-					alt={entry.title}
-					fill
-					unoptimized={true}
-					className="object-cover rounded-t-md"
-					sizes="80px"
-				/>
+				<Image src={entry.cover} alt={entry.title} fill unoptimized={true} className="object-cover rounded-t-md" sizes="80px" />
 			</div>
 			<HoverCard>
 				<HoverCardTrigger asChild>
-					<div className="text-xs line-clamp-2 h-11 w-full text-center p-1 text-foreground">
-						{entry.title}
-					</div>
+					<div className="text-xs line-clamp-2 h-11 w-full text-center p-1 text-foreground">{entry.title}</div>
 				</HoverCardTrigger>
-				<HoverCardContent className="w-64 p-2">
-					{entry.title}
-				</HoverCardContent>
+				<HoverCardContent className="w-64 p-2">{entry.title}</HoverCardContent>
 			</HoverCard>
 		</div>
-	)
+	);
 }

--- a/web/components/tiers/tier-config-modal.tsx
+++ b/web/components/tiers/tier-config-modal.tsx
@@ -1,24 +1,16 @@
 "use client";
-import {useEffect, useRef, useState} from "react";
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-	DialogTrigger,
-} from "@/components/ui/dialog";
-import {Button} from "@/components/ui/button";
-import {Input} from "@/components/ui/input";
-import {ArrowUpDown, Palette, Plus, Settings, X} from "lucide-react";
-import {HexColorPicker} from "react-colorful";
-import {Popover, PopoverContent, PopoverTrigger} from "@/components/ui/popover";
-import {Tier} from "@/components/model/types";
-import {useAuth} from "@/components/contexts/auth-context";
-import {getDefaultTiers} from "@/components/model/defaults";
-import {DataProvider, getProviderByName} from "@/components/data-providers/data-provider";
-import {TierConfigTableSkeleton} from "@/components/loading-skeletons/tier-config-table-skeleton";
+import { useEffect, useRef, useState } from "react";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ArrowUpDown, Palette, Plus, Settings, X } from "lucide-react";
+import { HexColorPicker } from "react-colorful";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Tier } from "@/components/model/types";
+import { useAuth } from "@/components/contexts/auth-context";
+import { getDefaultTiers } from "@/components/model/defaults";
+import { DataProvider, getProviderByName } from "@/components/data-providers/data-provider";
+import { TierConfigTableSkeleton } from "@/components/loading-skeletons/tier-config-table-skeleton";
 
 interface TierConfigModalProps {
 	initialTiers?: Tier[];
@@ -40,19 +32,12 @@ export const DEFAULT_COLORS = [
 	"#FF7FBF", // F - Pink
 ];
 
-export default function TierConfigModal({
-											initialTiers = [],
-											service,
-											type,
-											onSave,
-											username,
-											decimals
-										}: TierConfigModalProps) {
+export default function TierConfigModal({ initialTiers = [], service, type, onSave, username, decimals }: TierConfigModalProps) {
 	const [isOpen, setIsOpen] = useState(false);
 	const [tiers, setTiers] = useState<Tier[]>([]);
 	const [queryRunning, setQueryRunning] = useState(false);
 
-	const {token, isLoading, isAuthenticated, logout} = useAuth();
+	const { token, isLoading, isAuthenticated, logout } = useAuth();
 	const provider: DataProvider = getProviderByName(`${service}-${type}`);
 
 	const dataFetched = useRef(false);
@@ -61,7 +46,8 @@ export default function TierConfigModal({
 	useEffect(() => {
 		if (isOpen && !dataFetched.current && !isLoading && isAuthenticated) {
 			setQueryRunning(true);
-			provider.fetchTierlist(token, username, logout)
+			provider
+				.fetchTierlist(token, username, logout)
 				.then((data: Tier[]) => {
 					setTiers(data && data.length > 0 ? data : getDefaultTiers());
 					dataFetched.current = true;
@@ -77,14 +63,14 @@ export default function TierConfigModal({
 
 		const sortedTiers = [...tiers].sort((a, b) => b.score - a.score);
 		// Only update if the order has changed to avoid infinite loops
-		if (JSON.stringify(sortedTiers.map(t => t.id)) !== JSON.stringify(tiers.map(t => t.id))) {
+		if (JSON.stringify(sortedTiers.map((t) => t.id)) !== JSON.stringify(tiers.map((t) => t.id))) {
 			setTiers(sortedTiers);
 		}
 	}, [tiers]);
 
 	const restoreDefaults = () => {
 		setTiers(getDefaultTiers());
-	}
+	};
 
 	const addTier = () => {
 		if (!tiers) return;
@@ -92,9 +78,7 @@ export default function TierConfigModal({
 		const newIndex = tiers.length;
 		const defaultColor = DEFAULT_COLORS[newIndex % DEFAULT_COLORS.length];
 		// Find the lowest score and set new tier below it
-		const lowestScore = tiers.length > 0
-			? Math.min(...tiers.map(t => t.score))
-			: 10;
+		const lowestScore = tiers.length > 0 ? Math.min(...tiers.map((t) => t.score)) : 10;
 		const newScore = Math.max(0, lowestScore - 2);
 		const newTier = {
 			id: crypto.randomUUID(),
@@ -113,12 +97,12 @@ export default function TierConfigModal({
 	const updateTier = (id: string, field: keyof Tier, value: string | number) => {
 		const updatedTiers = tiers.map((tier) => {
 			if (tier.id === id) {
-				return {...tier, [field]: value};
+				return { ...tier, [field]: value };
 			}
 			return tier;
 		});
 		// If we're updating a score, sort the tiers
-		if (field === 'score') {
+		if (field === "score") {
 			setTiers(updatedTiers.sort((a, b) => b.score - a.score));
 		} else {
 			setTiers(updatedTiers);
@@ -171,26 +155,25 @@ export default function TierConfigModal({
 		<Dialog open={isOpen} onOpenChange={handleOpenChange}>
 			<DialogTrigger asChild className="p-0 cursor-pointer" onClick={handleOpenTrigger}>
 				<Button variant={"outline"}>
-					<Settings/>
+					<Settings />
 				</Button>
 			</DialogTrigger>
 			<DialogContent className="sm:max-w-[650px] max-h-[90vh]">
 				<DialogHeader>
 					<DialogTitle>Configure tier list</DialogTitle>
 					<DialogDescription>
-						Configure which <i>score</i> should be assigned to which tier.
-						When dropping an item into a new tier their score will be set to <i>adjusted score</i>.
+						Configure which <i>score</i> should be assigned to which tier. When dropping an item into a new tier their score
+						will be set to <i>adjusted score</i>.
 					</DialogDescription>
 					<p className="mt-1 font-medium text-sm flex items-center">
-						<ArrowUpDown className="h-3 w-3 mr-1"/>
+						<ArrowUpDown className="h-3 w-3 mr-1" />
 						Tiers are automatically sorted by score in descending order.
 					</p>
 				</DialogHeader>
 				<div className="space-y-6 py-4">
 					<div className="sm:max-w-fit max-w-[calc(100vw-5rem)] overflow-x-auto">
 						<div className="min-w-fit">
-							<div
-								className="grid grid-cols-[60px_minmax(120px,_1fr)_100px_120px_40px] gap-4 items-center font-medium text-sm pb-2">
+							<div className="grid grid-cols-[60px_minmax(120px,_1fr)_100px_120px_40px] gap-4 items-center font-medium text-sm pb-2">
 								<div>Color</div>
 								<div>Tier Name</div>
 								<div>Score</div>
@@ -199,9 +182,10 @@ export default function TierConfigModal({
 							</div>
 							<div className="max-h-[41vh] pr-1 overflow-y-auto">
 								{queryRunning ? (
-									<TierConfigTableSkeleton/>
+									<TierConfigTableSkeleton />
 								) : (
-									tiers && tiers.map((tier) => (
+									tiers &&
+									tiers.map((tier) => (
 										<div
 											key={tier.id}
 											className="grid grid-cols-[60px_minmax(120px,_1fr)_100px_120px_40px] gap-4 h-10 items-center"
@@ -213,11 +197,8 @@ export default function TierConfigModal({
 															variant="outline"
 															className="h-9 w-full p-1 flex justify-between items-center"
 														>
-															<div
-																className="h-6 w-6 rounded-sm"
-																style={{backgroundColor: tier.color}}
-															/>
-															<Palette className="h-4 w-4"/>
+															<div className="h-6 w-6 rounded-sm" style={{ backgroundColor: tier.color }} />
+															<Palette className="h-4 w-4" />
 														</Button>
 													</PopoverTrigger>
 													<PopoverContent className="w-auto p-3" align="start">
@@ -230,7 +211,7 @@ export default function TierConfigModal({
 																value={tier.color}
 																onChange={(e) => {
 																	const value = e.target.value;
-																	if (value.startsWith('#') || value === '') {
+																	if (value.startsWith("#") || value === "") {
 																		updateTier(tier.id, "color", value);
 																	}
 																}}
@@ -257,13 +238,7 @@ export default function TierConfigModal({
 												<Input
 													type="number"
 													value={tier.score}
-													onChange={(e) =>
-														updateTier(
-															tier.id,
-															"score",
-															formatNumberInput(e.target.value)
-														)
-													}
+													onChange={(e) => updateTier(tier.id, "score", formatNumberInput(e.target.value))}
 													step={decimals}
 													max="10"
 													min="0"
@@ -290,7 +265,7 @@ export default function TierConfigModal({
 												disabled={tiers.length <= 1}
 												className="w-9 hover:bg-red-100 dark:hover:bg-red-800/30 transition-colors"
 											>
-												<X className="h-4 w-4"/>
+												<X className="h-4 w-4" />
 											</Button>
 										</div>
 									))
@@ -298,13 +273,8 @@ export default function TierConfigModal({
 							</div>
 						</div>
 					</div>
-					<Button
-						variant="outline"
-						className="w-full flex items-center gap-2 h-9"
-						onClick={addTier}
-						disabled={queryRunning}
-					>
-						<Plus className="h-4 w-4"/> Add Tier
+					<Button variant="outline" className="w-full flex items-center gap-2 h-9" onClick={addTier} disabled={queryRunning}>
+						<Plus className="h-4 w-4" /> Add Tier
 					</Button>
 				</div>
 				<DialogFooter className="flex gap-2">

--- a/web/components/ui/alert.tsx
+++ b/web/components/ui/alert.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import {cva, type VariantProps} from "class-variance-authority"
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const alertVariants = cva(
 	"relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
@@ -9,58 +9,33 @@ const alertVariants = cva(
 		variants: {
 			variant: {
 				default: "bg-card text-card-foreground",
-				destructive:
-					"text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+				destructive: "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
 			},
 		},
 		defaultVariants: {
 			variant: "default",
 		},
 	}
-)
+);
 
-function Alert({
-				   className,
-				   variant,
-				   ...props
-			   }: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
-	return (
-		<div
-			data-slot="alert"
-			role="alert"
-			className={cn(alertVariants({variant}), className)}
-			{...props}
-		/>
-	)
+function Alert({ className, variant, ...props }: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+	return <div data-slot="alert" role="alert" className={cn(alertVariants({ variant }), className)} {...props} />;
 }
 
-function AlertTitle({className, ...props}: React.ComponentProps<"div">) {
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
 	return (
-		<div
-			data-slot="alert-title"
-			className={cn(
-				"col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
-				className
-			)}
-			{...props}
-		/>
-	)
+		<div data-slot="alert-title" className={cn("col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight", className)} {...props} />
+	);
 }
 
-function AlertDescription({
-							  className,
-							  ...props
-						  }: React.ComponentProps<"div">) {
+function AlertDescription({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<div
 			data-slot="alert-description"
-			className={cn(
-				"text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
-				className
-			)}
+			className={cn("text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed", className)}
 			{...props}
 		/>
-	)
+	);
 }
 
-export {Alert, AlertTitle, AlertDescription}
+export { Alert, AlertTitle, AlertDescription };

--- a/web/components/ui/aspect-ratio.tsx
+++ b/web/components/ui/aspect-ratio.tsx
@@ -1,11 +1,9 @@
-"use client"
+"use client";
 
-import * as AspectRatioPrimitive from "@radix-ui/react-aspect-ratio"
+import * as AspectRatioPrimitive from "@radix-ui/react-aspect-ratio";
 
-function AspectRatio({
-						 ...props
-					 }: React.ComponentProps<typeof AspectRatioPrimitive.Root>) {
-	return <AspectRatioPrimitive.Root data-slot="aspect-ratio" {...props} />
+function AspectRatio({ ...props }: React.ComponentProps<typeof AspectRatioPrimitive.Root>) {
+	return <AspectRatioPrimitive.Root data-slot="aspect-ratio" {...props} />;
 }
 
-export {AspectRatio}
+export { AspectRatio };

--- a/web/components/ui/avatar.tsx
+++ b/web/components/ui/avatar.tsx
@@ -1,53 +1,32 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as AvatarPrimitive from "@radix-ui/react-avatar"
+import * as React from "react";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function Avatar({
-					className,
-					...props
-				}: React.ComponentProps<typeof AvatarPrimitive.Root>) {
+function Avatar({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Root>) {
 	return (
 		<AvatarPrimitive.Root
 			data-slot="avatar"
-			className={cn(
-				"relative flex size-8 shrink-0 overflow-hidden rounded-full",
-				className
-			)}
+			className={cn("relative flex size-8 shrink-0 overflow-hidden rounded-full", className)}
 			{...props}
 		/>
-	)
+	);
 }
 
-function AvatarImage({
-						 className,
-						 ...props
-					 }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
-	return (
-		<AvatarPrimitive.Image
-			data-slot="avatar-image"
-			className={cn("aspect-square size-full", className)}
-			{...props}
-		/>
-	)
+function AvatarImage({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+	return <AvatarPrimitive.Image data-slot="avatar-image" className={cn("aspect-square size-full", className)} {...props} />;
 }
 
-function AvatarFallback({
-							className,
-							...props
-						}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+function AvatarFallback({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
 	return (
 		<AvatarPrimitive.Fallback
 			data-slot="avatar-fallback"
-			className={cn(
-				"bg-muted flex size-full items-center justify-center rounded-full",
-				className
-			)}
+			className={cn("bg-muted flex size-full items-center justify-center rounded-full", className)}
 			{...props}
 		/>
-	)
+	);
 }
 
-export {Avatar, AvatarImage, AvatarFallback}
+export { Avatar, AvatarImage, AvatarFallback };

--- a/web/components/ui/breadcrumb.tsx
+++ b/web/components/ui/breadcrumb.tsx
@@ -1,55 +1,40 @@
-import * as React from "react"
-import {Slot} from "@radix-ui/react-slot"
-import {ChevronRight, MoreHorizontal} from "lucide-react"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { ChevronRight, MoreHorizontal } from "lucide-react";
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function Breadcrumb({...props}: React.ComponentProps<"nav">) {
-	return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />
+function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
+	return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />;
 }
 
-function BreadcrumbList({className, ...props}: React.ComponentProps<"ol">) {
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
 	return (
 		<ol
 			data-slot="breadcrumb-list"
-			className={cn(
-				"text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5",
-				className
-			)}
+			className={cn("text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5", className)}
 			{...props}
 		/>
-	)
+	);
 }
 
-function BreadcrumbItem({className, ...props}: React.ComponentProps<"li">) {
-	return (
-		<li
-			data-slot="breadcrumb-item"
-			className={cn("inline-flex items-center gap-1.5", className)}
-			{...props}
-		/>
-	)
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+	return <li data-slot="breadcrumb-item" className={cn("inline-flex items-center gap-1.5", className)} {...props} />;
 }
 
 function BreadcrumbLink({
-							asChild,
-							className,
-							...props
-						}: React.ComponentProps<"a"> & {
-	asChild?: boolean
+	asChild,
+	className,
+	...props
+}: React.ComponentProps<"a"> & {
+	asChild?: boolean;
 }) {
-	const Comp = asChild ? Slot : "a"
+	const Comp = asChild ? Slot : "a";
 
-	return (
-		<Comp
-			data-slot="breadcrumb-link"
-			className={cn("hover:text-foreground transition-colors", className)}
-			{...props}
-		/>
-	)
+	return <Comp data-slot="breadcrumb-link" className={cn("hover:text-foreground transition-colors", className)} {...props} />;
 }
 
-function BreadcrumbPage({className, ...props}: React.ComponentProps<"span">) {
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
 	return (
 		<span
 			data-slot="breadcrumb-page"
@@ -59,14 +44,10 @@ function BreadcrumbPage({className, ...props}: React.ComponentProps<"span">) {
 			className={cn("text-foreground font-normal", className)}
 			{...props}
 		/>
-	)
+	);
 }
 
-function BreadcrumbSeparator({
-								 children,
-								 className,
-								 ...props
-							 }: React.ComponentProps<"li">) {
+function BreadcrumbSeparator({ children, className, ...props }: React.ComponentProps<"li">) {
 	return (
 		<li
 			data-slot="breadcrumb-separator"
@@ -75,15 +56,12 @@ function BreadcrumbSeparator({
 			className={cn("[&>svg]:size-3.5", className)}
 			{...props}
 		>
-			{children ?? <ChevronRight/>}
+			{children ?? <ChevronRight />}
 		</li>
-	)
+	);
 }
 
-function BreadcrumbEllipsis({
-								className,
-								...props
-							}: React.ComponentProps<"span">) {
+function BreadcrumbEllipsis({ className, ...props }: React.ComponentProps<"span">) {
 	return (
 		<span
 			data-slot="breadcrumb-ellipsis"
@@ -92,18 +70,10 @@ function BreadcrumbEllipsis({
 			className={cn("flex size-9 items-center justify-center", className)}
 			{...props}
 		>
-      <MoreHorizontal className="size-4"/>
-      <span className="sr-only">More</span>
-    </span>
-	)
+			<MoreHorizontal className="size-4" />
+			<span className="sr-only">More</span>
+		</span>
+	);
 }
 
-export {
-	Breadcrumb,
-	BreadcrumbList,
-	BreadcrumbItem,
-	BreadcrumbLink,
-	BreadcrumbPage,
-	BreadcrumbSeparator,
-	BreadcrumbEllipsis,
-}
+export { Breadcrumb, BreadcrumbList, BreadcrumbItem, BreadcrumbLink, BreadcrumbPage, BreadcrumbSeparator, BreadcrumbEllipsis };

--- a/web/components/ui/button-group.tsx
+++ b/web/components/ui/button-group.tsx
@@ -1,8 +1,8 @@
-import {Slot} from "@radix-ui/react-slot"
-import {cva, type VariantProps} from "class-variance-authority"
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import {cn} from "@/lib/utils"
-import {Separator} from "@/components/ui/separator"
+import { cn } from "@/lib/utils";
+import { Separator } from "@/components/ui/separator";
 
 const buttonGroupVariants = cva(
 	"flex w-fit items-stretch [&>*]:focus-visible:z-10 [&>*]:focus-visible:relative [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md has-[>[data-slot=button-group]]:gap-2",
@@ -19,32 +19,28 @@ const buttonGroupVariants = cva(
 			orientation: "horizontal",
 		},
 	}
-)
+);
 
-function ButtonGroup({
-						 className,
-						 orientation,
-						 ...props
-					 }: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
+function ButtonGroup({ className, orientation, ...props }: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
 	return (
 		<div
 			role="group"
 			data-slot="button-group"
 			data-orientation={orientation}
-			className={cn(buttonGroupVariants({orientation}), className)}
+			className={cn(buttonGroupVariants({ orientation }), className)}
 			{...props}
 		/>
-	)
+	);
 }
 
 function ButtonGroupText({
-							 className,
-							 asChild = false,
-							 ...props
-						 }: React.ComponentProps<"div"> & {
-	asChild?: boolean
+	className,
+	asChild = false,
+	...props
+}: React.ComponentProps<"div"> & {
+	asChild?: boolean;
 }) {
-	const Comp = asChild ? Slot : "div"
+	const Comp = asChild ? Slot : "div";
 
 	return (
 		<Comp
@@ -54,30 +50,18 @@ function ButtonGroupText({
 			)}
 			{...props}
 		/>
-	)
+	);
 }
 
-function ButtonGroupSeparator({
-								  className,
-								  orientation = "vertical",
-								  ...props
-							  }: React.ComponentProps<typeof Separator>) {
+function ButtonGroupSeparator({ className, orientation = "vertical", ...props }: React.ComponentProps<typeof Separator>) {
 	return (
 		<Separator
 			data-slot="button-group-separator"
 			orientation={orientation}
-			className={cn(
-				"bg-input relative !m-0 self-stretch data-[orientation=vertical]:h-auto",
-				className
-			)}
+			className={cn("bg-input relative !m-0 self-stretch data-[orientation=vertical]:h-auto", className)}
 			{...props}
 		/>
-	)
+	);
 }
 
-export {
-	ButtonGroup,
-	ButtonGroupSeparator,
-	ButtonGroupText,
-	buttonGroupVariants,
-}
+export { ButtonGroup, ButtonGroupSeparator, ButtonGroupText, buttonGroupVariants };

--- a/web/components/ui/button.tsx
+++ b/web/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import {Slot} from "@radix-ui/react-slot"
-import {cva, type VariantProps} from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
 	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -14,10 +14,8 @@ const buttonVariants = cva(
 					"bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
 				outline:
 					"border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
-				secondary:
-					"bg-secondary text-secondary-foreground hover:bg-secondary/80",
-				ghost:
-					"hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+				secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+				ghost: "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
 				link: "text-primary underline-offset-4 hover:underline",
 			},
 			size: {
@@ -34,27 +32,21 @@ const buttonVariants = cva(
 			size: "default",
 		},
 	}
-)
+);
 
 function Button({
-					className,
-					variant,
-					size,
-					asChild = false,
-					...props
-				}: React.ComponentProps<"button"> &
+	className,
+	variant,
+	size,
+	asChild = false,
+	...props
+}: React.ComponentProps<"button"> &
 	VariantProps<typeof buttonVariants> & {
-	asChild?: boolean
-}) {
-	const Comp = asChild ? Slot : "button"
+		asChild?: boolean;
+	}) {
+	const Comp = asChild ? Slot : "button";
 
-	return (
-		<Comp
-			data-slot="button"
-			className={cn(buttonVariants({variant, size, className}))}
-			{...props}
-		/>
-	)
+	return <Comp data-slot="button" className={cn(buttonVariants({ variant, size, className }))} {...props} />;
 }
 
-export {Button, buttonVariants}
+export { Button, buttonVariants };

--- a/web/components/ui/card.tsx
+++ b/web/components/ui/card.tsx
@@ -1,21 +1,18 @@
-import * as React from "react"
+import * as React from "react";
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function Card({className, ...props}: React.ComponentProps<"div">) {
+function Card({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<div
 			data-slot="card"
-			className={cn(
-				"bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
-				className
-			)}
+			className={cn("bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm", className)}
 			{...props}
 		/>
-	)
+	);
 }
 
-function CardHeader({className, ...props}: React.ComponentProps<"div">) {
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<div
 			data-slot="card-header"
@@ -25,68 +22,33 @@ function CardHeader({className, ...props}: React.ComponentProps<"div">) {
 			)}
 			{...props}
 		/>
-	)
+	);
 }
 
-function CardTitle({className, ...props}: React.ComponentProps<"div">) {
-	return (
-		<div
-			data-slot="card-title"
-			className={cn("leading-none font-semibold", className)}
-			{...props}
-		/>
-	)
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+	return <div data-slot="card-title" className={cn("leading-none font-semibold", className)} {...props} />;
 }
 
-function CardDescription({className, ...props}: React.ComponentProps<"div">) {
-	return (
-		<div
-			data-slot="card-description"
-			className={cn("text-muted-foreground text-sm", className)}
-			{...props}
-		/>
-	)
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+	return <div data-slot="card-description" className={cn("text-muted-foreground text-sm", className)} {...props} />;
 }
 
-function CardAction({className, ...props}: React.ComponentProps<"div">) {
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<div
 			data-slot="card-action"
-			className={cn(
-				"col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-				className
-			)}
+			className={cn("col-start-2 row-span-2 row-start-1 self-start justify-self-end", className)}
 			{...props}
 		/>
-	)
+	);
 }
 
-function CardContent({className, ...props}: React.ComponentProps<"div">) {
-	return (
-		<div
-			data-slot="card-content"
-			className={cn("px-6", className)}
-			{...props}
-		/>
-	)
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+	return <div data-slot="card-content" className={cn("px-6", className)} {...props} />;
 }
 
-function CardFooter({className, ...props}: React.ComponentProps<"div">) {
-	return (
-		<div
-			data-slot="card-footer"
-			className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
-			{...props}
-		/>
-	)
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+	return <div data-slot="card-footer" className={cn("flex items-center px-6 [.border-t]:pt-6", className)} {...props} />;
 }
 
-export {
-	Card,
-	CardHeader,
-	CardFooter,
-	CardTitle,
-	CardAction,
-	CardDescription,
-	CardContent,
-}
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };

--- a/web/components/ui/dialog.tsx
+++ b/web/components/ui/dialog.tsx
@@ -1,40 +1,29 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import {XIcon} from "lucide-react"
-import {Dialog as DialogPrimitive} from "radix-ui"
+import * as React from "react";
+import { XIcon } from "lucide-react";
+import { Dialog as DialogPrimitive } from "radix-ui";
 
-import {cn} from "@/lib/utils"
-import {Button} from "@/components/ui/button"
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
-function Dialog({
-					...props
-				}: React.ComponentProps<typeof DialogPrimitive.Root>) {
-	return <DialogPrimitive.Root data-slot="dialog" {...props} />
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+	return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
-function DialogTrigger({
-						   ...props
-					   }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-	return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+	return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
-function DialogPortal({
-						  ...props
-					  }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-	return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+	return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
-function DialogClose({
-						 ...props
-					 }: React.ComponentProps<typeof DialogPrimitive.Close>) {
-	return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+	return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
-function DialogOverlay({
-						   className,
-						   ...props
-					   }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+function DialogOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
 	return (
 		<DialogPrimitive.Overlay
 			data-slot="dialog-overlay"
@@ -44,20 +33,20 @@ function DialogOverlay({
 			)}
 			{...props}
 		/>
-	)
+	);
 }
 
 function DialogContent({
-						   className,
-						   children,
-						   showCloseButton = true,
-						   ...props
-					   }: React.ComponentProps<typeof DialogPrimitive.Content> & {
-	showCloseButton?: boolean
+	className,
+	children,
+	showCloseButton = true,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+	showCloseButton?: boolean;
 }) {
 	return (
 		<DialogPortal data-slot="dialog-portal">
-			<DialogOverlay/>
+			<DialogOverlay />
 			<DialogPrimitive.Content
 				data-slot="dialog-content"
 				className={cn(
@@ -72,42 +61,29 @@ function DialogContent({
 						data-slot="dialog-close"
 						className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
 					>
-						<XIcon/>
+						<XIcon />
 						<span className="sr-only">Close</span>
 					</DialogPrimitive.Close>
 				)}
 			</DialogPrimitive.Content>
 		</DialogPortal>
-	)
+	);
 }
 
-function DialogHeader({className, ...props}: React.ComponentProps<"div">) {
-	return (
-		<div
-			data-slot="dialog-header"
-			className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
-			{...props}
-		/>
-	)
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return <div data-slot="dialog-header" className={cn("flex flex-col gap-2 text-center sm:text-left", className)} {...props} />;
 }
 
 function DialogFooter({
-						  className,
-						  showCloseButton = false,
-						  children,
-						  ...props
-					  }: React.ComponentProps<"div"> & {
-	showCloseButton?: boolean
+	className,
+	showCloseButton = false,
+	children,
+	...props
+}: React.ComponentProps<"div"> & {
+	showCloseButton?: boolean;
 }) {
 	return (
-		<div
-			data-slot="dialog-footer"
-			className={cn(
-				"flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-				className
-			)}
-			{...props}
-		>
+		<div data-slot="dialog-footer" className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)} {...props}>
 			{children}
 			{showCloseButton && (
 				<DialogPrimitive.Close asChild>
@@ -115,33 +91,17 @@ function DialogFooter({
 				</DialogPrimitive.Close>
 			)}
 		</div>
-	)
+	);
 }
 
-function DialogTitle({
-						 className,
-						 ...props
-					 }: React.ComponentProps<typeof DialogPrimitive.Title>) {
-	return (
-		<DialogPrimitive.Title
-			data-slot="dialog-title"
-			className={cn("text-lg leading-none font-semibold", className)}
-			{...props}
-		/>
-	)
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+	return <DialogPrimitive.Title data-slot="dialog-title" className={cn("text-lg leading-none font-semibold", className)} {...props} />;
 }
 
-function DialogDescription({
-							   className,
-							   ...props
-						   }: React.ComponentProps<typeof DialogPrimitive.Description>) {
+function DialogDescription({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) {
 	return (
-		<DialogPrimitive.Description
-			data-slot="dialog-description"
-			className={cn("text-muted-foreground text-sm", className)}
-			{...props}
-		/>
-	)
+		<DialogPrimitive.Description data-slot="dialog-description" className={cn("text-muted-foreground text-sm", className)} {...props} />
+	);
 }
 
 export {
@@ -155,4 +115,4 @@ export {
 	DialogPortal,
 	DialogTitle,
 	DialogTrigger,
-}
+};

--- a/web/components/ui/dropdown-menu.tsx
+++ b/web/components/ui/dropdown-menu.tsx
@@ -1,41 +1,24 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import {CheckIcon, ChevronRightIcon, CircleIcon} from "lucide-react"
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function DropdownMenu({
-						  ...props
-					  }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
-	return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+	return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
 }
 
-function DropdownMenuPortal({
-								...props
-							}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
-	return (
-		<DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
-	)
+function DropdownMenuPortal({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+	return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
 }
 
-function DropdownMenuTrigger({
-								 ...props
-							 }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
-	return (
-		<DropdownMenuPrimitive.Trigger
-			data-slot="dropdown-menu-trigger"
-			{...props}
-		/>
-	)
+function DropdownMenuTrigger({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+	return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
 }
 
-function DropdownMenuContent({
-								 className,
-								 sideOffset = 4,
-								 ...props
-							 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+function DropdownMenuContent({ className, sideOffset = 4, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
 	return (
 		<DropdownMenuPrimitive.Portal>
 			<DropdownMenuPrimitive.Content
@@ -48,25 +31,21 @@ function DropdownMenuContent({
 				{...props}
 			/>
 		</DropdownMenuPrimitive.Portal>
-	)
+	);
 }
 
-function DropdownMenuGroup({
-							   ...props
-						   }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
-	return (
-		<DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
-	)
+function DropdownMenuGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+	return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
 }
 
 function DropdownMenuItem({
-							  className,
-							  inset,
-							  variant = "default",
-							  ...props
-						  }: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
-	inset?: boolean
-	variant?: "default" | "destructive"
+	className,
+	inset,
+	variant = "default",
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+	inset?: boolean;
+	variant?: "default" | "destructive";
 }) {
 	return (
 		<DropdownMenuPrimitive.Item
@@ -79,15 +58,15 @@ function DropdownMenuItem({
 			)}
 			{...props}
 		/>
-	)
+	);
 }
 
 function DropdownMenuCheckboxItem({
-									  className,
-									  children,
-									  checked,
-									  ...props
-								  }: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+	className,
+	children,
+	checked,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
 	return (
 		<DropdownMenuPrimitive.CheckboxItem
 			data-slot="dropdown-menu-checkbox-item"
@@ -98,32 +77,21 @@ function DropdownMenuCheckboxItem({
 			checked={checked}
 			{...props}
 		>
-      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon className="size-4"/>
-        </DropdownMenuPrimitive.ItemIndicator>
-      </span>
+			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+				<DropdownMenuPrimitive.ItemIndicator>
+					<CheckIcon className="size-4" />
+				</DropdownMenuPrimitive.ItemIndicator>
+			</span>
 			{children}
 		</DropdownMenuPrimitive.CheckboxItem>
-	)
+	);
 }
 
-function DropdownMenuRadioGroup({
-									...props
-								}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
-	return (
-		<DropdownMenuPrimitive.RadioGroup
-			data-slot="dropdown-menu-radio-group"
-			{...props}
-		/>
-	)
+function DropdownMenuRadioGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+	return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />;
 }
 
-function DropdownMenuRadioItem({
-								   className,
-								   children,
-								   ...props
-							   }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+function DropdownMenuRadioItem({ className, children, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
 	return (
 		<DropdownMenuPrimitive.RadioItem
 			data-slot="dropdown-menu-radio-item"
@@ -133,78 +101,64 @@ function DropdownMenuRadioItem({
 			)}
 			{...props}
 		>
-      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
-          <CircleIcon className="size-2 fill-current"/>
-        </DropdownMenuPrimitive.ItemIndicator>
-      </span>
+			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+				<DropdownMenuPrimitive.ItemIndicator>
+					<CircleIcon className="size-2 fill-current" />
+				</DropdownMenuPrimitive.ItemIndicator>
+			</span>
 			{children}
 		</DropdownMenuPrimitive.RadioItem>
-	)
+	);
 }
 
 function DropdownMenuLabel({
-							   className,
-							   inset,
-							   ...props
-						   }: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
-	inset?: boolean
+	className,
+	inset,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+	inset?: boolean;
 }) {
 	return (
 		<DropdownMenuPrimitive.Label
 			data-slot="dropdown-menu-label"
 			data-inset={inset}
-			className={cn(
-				"px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
-				className
-			)}
+			className={cn("px-2 py-1.5 text-sm font-medium data-[inset]:pl-8", className)}
 			{...props}
 		/>
-	)
+	);
 }
 
-function DropdownMenuSeparator({
-								   className,
-								   ...props
-							   }: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+function DropdownMenuSeparator({ className, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
 	return (
 		<DropdownMenuPrimitive.Separator
 			data-slot="dropdown-menu-separator"
 			className={cn("bg-border -mx-1 my-1 h-px", className)}
 			{...props}
 		/>
-	)
+	);
 }
 
-function DropdownMenuShortcut({
-								  className,
-								  ...props
-							  }: React.ComponentProps<"span">) {
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
 	return (
 		<span
 			data-slot="dropdown-menu-shortcut"
-			className={cn(
-				"text-muted-foreground ml-auto text-xs tracking-widest",
-				className
-			)}
+			className={cn("text-muted-foreground ml-auto text-xs tracking-widest", className)}
 			{...props}
 		/>
-	)
+	);
 }
 
-function DropdownMenuSub({
-							 ...props
-						 }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
-	return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+	return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
 }
 
 function DropdownMenuSubTrigger({
-									className,
-									inset,
-									children,
-									...props
-								}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
-	inset?: boolean
+	className,
+	inset,
+	children,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+	inset?: boolean;
 }) {
 	return (
 		<DropdownMenuPrimitive.SubTrigger
@@ -217,15 +171,12 @@ function DropdownMenuSubTrigger({
 			{...props}
 		>
 			{children}
-			<ChevronRightIcon className="ml-auto size-4"/>
+			<ChevronRightIcon className="ml-auto size-4" />
 		</DropdownMenuPrimitive.SubTrigger>
-	)
+	);
 }
 
-function DropdownMenuSubContent({
-									className,
-									...props
-								}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+function DropdownMenuSubContent({ className, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
 	return (
 		<DropdownMenuPrimitive.SubContent
 			data-slot="dropdown-menu-sub-content"
@@ -235,7 +186,7 @@ function DropdownMenuSubContent({
 			)}
 			{...props}
 		/>
-	)
+	);
 }
 
 export {
@@ -254,4 +205,4 @@ export {
 	DropdownMenuSub,
 	DropdownMenuSubTrigger,
 	DropdownMenuSubContent,
-}
+};

--- a/web/components/ui/form.tsx
+++ b/web/components/ui/form.tsx
@@ -1,59 +1,54 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import {Slot} from "@radix-ui/react-slot"
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
 import {
 	Controller,
-	type ControllerProps,
-	type FieldPath,
-	type FieldValues,
 	FormProvider,
 	useFormContext,
 	useFormState,
-} from "react-hook-form"
+	type ControllerProps,
+	type FieldPath,
+	type FieldValues,
+} from "react-hook-form";
 
-import {cn} from "@/lib/utils"
-import {Label} from "@/components/ui/label"
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
 
-const Form = FormProvider
+const Form = FormProvider;
 
 type FormFieldContextValue<
 	TFieldValues extends FieldValues = FieldValues,
 	TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 > = {
-	name: TName
-}
+	name: TName;
+};
 
-const FormFieldContext = React.createContext<FormFieldContextValue>(
-	{} as FormFieldContextValue
-)
+const FormFieldContext = React.createContext<FormFieldContextValue>({} as FormFieldContextValue);
 
-const FormField = <
-	TFieldValues extends FieldValues = FieldValues,
-	TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
->({
-	  ...props
-  }: ControllerProps<TFieldValues, TName>) => {
+const FormField = <TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>>({
+	...props
+}: ControllerProps<TFieldValues, TName>) => {
 	return (
-		<FormFieldContext.Provider value={{name: props.name}}>
+		<FormFieldContext.Provider value={{ name: props.name }}>
 			<Controller {...props} />
 		</FormFieldContext.Provider>
-	)
-}
+	);
+};
 
 const useFormField = () => {
-	const fieldContext = React.useContext(FormFieldContext)
-	const itemContext = React.useContext(FormItemContext)
-	const {getFieldState} = useFormContext()
-	const formState = useFormState({name: fieldContext.name})
-	const fieldState = getFieldState(fieldContext.name, formState)
+	const fieldContext = React.useContext(FormFieldContext);
+	const itemContext = React.useContext(FormItemContext);
+	const { getFieldState } = useFormContext();
+	const formState = useFormState({ name: fieldContext.name });
+	const fieldState = getFieldState(fieldContext.name, formState);
 
 	if (!fieldContext) {
-		throw new Error("useFormField should be used within <FormField>")
+		throw new Error("useFormField should be used within <FormField>");
 	}
 
-	const {id} = itemContext
+	const { id } = itemContext;
 
 	return {
 		id,
@@ -62,36 +57,27 @@ const useFormField = () => {
 		formDescriptionId: `${id}-form-item-description`,
 		formMessageId: `${id}-form-item-message`,
 		...fieldState,
-	}
-}
+	};
+};
 
 type FormItemContextValue = {
-	id: string
-}
+	id: string;
+};
 
-const FormItemContext = React.createContext<FormItemContextValue>(
-	{} as FormItemContextValue
-)
+const FormItemContext = React.createContext<FormItemContextValue>({} as FormItemContextValue);
 
-function FormItem({className, ...props}: React.ComponentProps<"div">) {
-	const id = React.useId()
+function FormItem({ className, ...props }: React.ComponentProps<"div">) {
+	const id = React.useId();
 
 	return (
-		<FormItemContext.Provider value={{id}}>
-			<div
-				data-slot="form-item"
-				className={cn("grid gap-2", className)}
-				{...props}
-			/>
+		<FormItemContext.Provider value={{ id }}>
+			<div data-slot="form-item" className={cn("grid gap-2", className)} {...props} />
 		</FormItemContext.Provider>
-	)
+	);
 }
 
-function FormLabel({
-					   className,
-					   ...props
-				   }: React.ComponentProps<typeof LabelPrimitive.Root>) {
-	const {error, formItemId} = useFormField()
+function FormLabel({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
+	const { error, formItemId } = useFormField();
 
 	return (
 		<Label
@@ -101,67 +87,42 @@ function FormLabel({
 			htmlFor={formItemId}
 			{...props}
 		/>
-	)
+	);
 }
 
-function FormControl({...props}: React.ComponentProps<typeof Slot>) {
-	const {error, formItemId, formDescriptionId, formMessageId} = useFormField()
+function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
+	const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
 
 	return (
 		<Slot
 			data-slot="form-control"
 			id={formItemId}
-			aria-describedby={
-				!error
-					? `${formDescriptionId}`
-					: `${formDescriptionId} ${formMessageId}`
-			}
+			aria-describedby={!error ? `${formDescriptionId}` : `${formDescriptionId} ${formMessageId}`}
 			aria-invalid={!!error}
 			{...props}
 		/>
-	)
+	);
 }
 
-function FormDescription({className, ...props}: React.ComponentProps<"p">) {
-	const {formDescriptionId} = useFormField()
+function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
+	const { formDescriptionId } = useFormField();
 
-	return (
-		<p
-			data-slot="form-description"
-			id={formDescriptionId}
-			className={cn("text-muted-foreground text-sm", className)}
-			{...props}
-		/>
-	)
+	return <p data-slot="form-description" id={formDescriptionId} className={cn("text-muted-foreground text-sm", className)} {...props} />;
 }
 
-function FormMessage({className, ...props}: React.ComponentProps<"p">) {
-	const {error, formMessageId} = useFormField()
-	const body = error ? String(error?.message ?? "") : props.children
+function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
+	const { error, formMessageId } = useFormField();
+	const body = error ? String(error?.message ?? "") : props.children;
 
 	if (!body) {
-		return null
+		return null;
 	}
 
 	return (
-		<p
-			data-slot="form-message"
-			id={formMessageId}
-			className={cn("text-destructive text-sm", className)}
-			{...props}
-		>
+		<p data-slot="form-message" id={formMessageId} className={cn("text-destructive text-sm", className)} {...props}>
 			{body}
 		</p>
-	)
+	);
 }
 
-export {
-	useFormField,
-	Form,
-	FormItem,
-	FormLabel,
-	FormControl,
-	FormDescription,
-	FormMessage,
-	FormField,
-}
+export { useFormField, Form, FormItem, FormLabel, FormControl, FormDescription, FormMessage, FormField };

--- a/web/components/ui/hover-card.tsx
+++ b/web/components/ui/hover-card.tsx
@@ -1,30 +1,24 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
+import * as React from "react";
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function HoverCard({
-					   ...props
-				   }: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
-	return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />
+function HoverCard({ ...props }: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
+	return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />;
 }
 
-function HoverCardTrigger({
-							  ...props
-						  }: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
-	return (
-		<HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
-	)
+function HoverCardTrigger({ ...props }: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
+	return <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />;
 }
 
 function HoverCardContent({
-							  className,
-							  align = "center",
-							  sideOffset = 4,
-							  ...props
-						  }: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+	className,
+	align = "center",
+	sideOffset = 4,
+	...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
 	return (
 		<HoverCardPrimitive.Portal data-slot="hover-card-portal">
 			<HoverCardPrimitive.Content
@@ -38,7 +32,7 @@ function HoverCardContent({
 				{...props}
 			/>
 		</HoverCardPrimitive.Portal>
-	)
+	);
 }
 
-export {HoverCard, HoverCardTrigger, HoverCardContent}
+export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/web/components/ui/input.tsx
+++ b/web/components/ui/input.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
+import * as React from "react";
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function Input({className, type, ...props}: React.ComponentProps<"input">) {
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
 	return (
 		<input
 			type={type}
@@ -15,7 +15,7 @@ function Input({className, type, ...props}: React.ComponentProps<"input">) {
 			)}
 			{...props}
 		/>
-	)
+	);
 }
 
-export {Input}
+export { Input };

--- a/web/components/ui/label.tsx
+++ b/web/components/ui/label.tsx
@@ -1,14 +1,11 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function Label({
-				   className,
-				   ...props
-			   }: React.ComponentProps<typeof LabelPrimitive.Root>) {
+function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
 	return (
 		<LabelPrimitive.Root
 			data-slot="label"
@@ -18,7 +15,7 @@ function Label({
 			)}
 			{...props}
 		/>
-	)
+	);
 }
 
-export {Label}
+export { Label };

--- a/web/components/ui/navigation-menu.tsx
+++ b/web/components/ui/navigation-menu.tsx
@@ -1,72 +1,50 @@
-import * as React from "react"
-import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
-import {cva} from "class-variance-authority"
-import {ChevronDownIcon} from "lucide-react"
+import * as React from "react";
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
+import { cva } from "class-variance-authority";
+import { ChevronDownIcon } from "lucide-react";
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function NavigationMenu({
-							className,
-							children,
-							viewport = true,
-							...props
-						}: React.ComponentProps<typeof NavigationMenuPrimitive.Root> & {
-	viewport?: boolean
+	className,
+	children,
+	viewport = true,
+	...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Root> & {
+	viewport?: boolean;
 }) {
 	return (
 		<NavigationMenuPrimitive.Root
 			data-slot="navigation-menu"
 			data-viewport={viewport}
-			className={cn(
-				"group/navigation-menu relative flex max-w-max flex-1 items-center justify-center",
-				className
-			)}
+			className={cn("group/navigation-menu relative flex max-w-max flex-1 items-center justify-center", className)}
 			{...props}
 		>
 			{children}
-			{viewport && <NavigationMenuViewport/>}
+			{viewport && <NavigationMenuViewport />}
 		</NavigationMenuPrimitive.Root>
-	)
+	);
 }
 
-function NavigationMenuList({
-								className,
-								...props
-							}: React.ComponentProps<typeof NavigationMenuPrimitive.List>) {
+function NavigationMenuList({ className, ...props }: React.ComponentProps<typeof NavigationMenuPrimitive.List>) {
 	return (
 		<NavigationMenuPrimitive.List
 			data-slot="navigation-menu-list"
-			className={cn(
-				"group flex flex-1 list-none items-center justify-center gap-1",
-				className
-			)}
+			className={cn("group flex flex-1 list-none items-center justify-center gap-1", className)}
 			{...props}
 		/>
-	)
+	);
 }
 
-function NavigationMenuItem({
-								className,
-								...props
-							}: React.ComponentProps<typeof NavigationMenuPrimitive.Item>) {
-	return (
-		<NavigationMenuPrimitive.Item
-			data-slot="navigation-menu-item"
-			className={cn("relative", className)}
-			{...props}
-		/>
-	)
+function NavigationMenuItem({ className, ...props }: React.ComponentProps<typeof NavigationMenuPrimitive.Item>) {
+	return <NavigationMenuPrimitive.Item data-slot="navigation-menu-item" className={cn("relative", className)} {...props} />;
 }
 
 const navigationMenuTriggerStyle = cva(
 	"group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent data-[state=open]:text-accent-foreground data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1"
-)
+);
 
-function NavigationMenuTrigger({
-								   className,
-								   children,
-								   ...props
-							   }: React.ComponentProps<typeof NavigationMenuPrimitive.Trigger>) {
+function NavigationMenuTrigger({ className, children, ...props }: React.ComponentProps<typeof NavigationMenuPrimitive.Trigger>) {
 	return (
 		<NavigationMenuPrimitive.Trigger
 			data-slot="navigation-menu-trigger"
@@ -79,13 +57,10 @@ function NavigationMenuTrigger({
 				aria-hidden="true"
 			/>
 		</NavigationMenuPrimitive.Trigger>
-	)
+	);
 }
 
-function NavigationMenuContent({
-								   className,
-								   ...props
-							   }: React.ComponentProps<typeof NavigationMenuPrimitive.Content>) {
+function NavigationMenuContent({ className, ...props }: React.ComponentProps<typeof NavigationMenuPrimitive.Content>) {
 	return (
 		<NavigationMenuPrimitive.Content
 			data-slot="navigation-menu-content"
@@ -96,19 +71,12 @@ function NavigationMenuContent({
 			)}
 			{...props}
 		/>
-	)
+	);
 }
 
-function NavigationMenuViewport({
-									className,
-									...props
-								}: React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>) {
+function NavigationMenuViewport({ className, ...props }: React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>) {
 	return (
-		<div
-			className={cn(
-				"absolute top-full left-0 isolate z-50 flex justify-center"
-			)}
-		>
+		<div className={cn("absolute top-full left-0 isolate z-50 flex justify-center")}>
 			<NavigationMenuPrimitive.Viewport
 				data-slot="navigation-menu-viewport"
 				className={cn(
@@ -118,13 +86,10 @@ function NavigationMenuViewport({
 				{...props}
 			/>
 		</div>
-	)
+	);
 }
 
-function NavigationMenuLink({
-								className,
-								...props
-							}: React.ComponentProps<typeof NavigationMenuPrimitive.Link>) {
+function NavigationMenuLink({ className, ...props }: React.ComponentProps<typeof NavigationMenuPrimitive.Link>) {
 	return (
 		<NavigationMenuPrimitive.Link
 			data-slot="navigation-menu-link"
@@ -134,13 +99,10 @@ function NavigationMenuLink({
 			)}
 			{...props}
 		/>
-	)
+	);
 }
 
-function NavigationMenuIndicator({
-									 className,
-									 ...props
-								 }: React.ComponentProps<typeof NavigationMenuPrimitive.Indicator>) {
+function NavigationMenuIndicator({ className, ...props }: React.ComponentProps<typeof NavigationMenuPrimitive.Indicator>) {
 	return (
 		<NavigationMenuPrimitive.Indicator
 			data-slot="navigation-menu-indicator"
@@ -150,9 +112,9 @@ function NavigationMenuIndicator({
 			)}
 			{...props}
 		>
-			<div className="bg-border relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm shadow-md"/>
+			<div className="bg-border relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm shadow-md" />
 		</NavigationMenuPrimitive.Indicator>
-	)
+	);
 }
 
 export {
@@ -165,4 +127,4 @@ export {
 	NavigationMenuIndicator,
 	NavigationMenuViewport,
 	navigationMenuTriggerStyle,
-}
+};

--- a/web/components/ui/popover.tsx
+++ b/web/components/ui/popover.tsx
@@ -1,28 +1,19 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as PopoverPrimitive from "@radix-ui/react-popover"
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function Popover({
-					 ...props
-				 }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
-	return <PopoverPrimitive.Root data-slot="popover" {...props} />
+function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+	return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
-function PopoverTrigger({
-							...props
-						}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
-	return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+	return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
 }
 
-function PopoverContent({
-							className,
-							align = "center",
-							sideOffset = 4,
-							...props
-						}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+function PopoverContent({ className, align = "center", sideOffset = 4, ...props }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
 	return (
 		<PopoverPrimitive.Portal>
 			<PopoverPrimitive.Content
@@ -36,13 +27,11 @@ function PopoverContent({
 				{...props}
 			/>
 		</PopoverPrimitive.Portal>
-	)
+	);
 }
 
-function PopoverAnchor({
-						   ...props
-					   }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
-	return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+	return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
 }
 
-export {Popover, PopoverTrigger, PopoverContent, PopoverAnchor}
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/web/components/ui/separator.tsx
+++ b/web/components/ui/separator.tsx
@@ -1,16 +1,16 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as SeparatorPrimitive from "@radix-ui/react-separator"
+import * as React from "react";
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Separator({
-					   className,
-					   orientation = "horizontal",
-					   decorative = true,
-					   ...props
-				   }: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+	className,
+	orientation = "horizontal",
+	decorative = true,
+	...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
 	return (
 		<SeparatorPrimitive.Root
 			data-slot="separator"
@@ -22,7 +22,7 @@ function Separator({
 			)}
 			{...props}
 		/>
-	)
+	);
 }
 
-export {Separator}
+export { Separator };

--- a/web/components/ui/sheet.tsx
+++ b/web/components/ui/sheet.tsx
@@ -1,37 +1,28 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as SheetPrimitive from "@radix-ui/react-dialog"
-import {XIcon} from "lucide-react"
+import * as React from "react";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function Sheet({...props}: React.ComponentProps<typeof SheetPrimitive.Root>) {
-	return <SheetPrimitive.Root data-slot="sheet" {...props} />
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+	return <SheetPrimitive.Root data-slot="sheet" {...props} />;
 }
 
-function SheetTrigger({
-						  ...props
-					  }: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
-	return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+function SheetTrigger({ ...props }: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+	return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
 }
 
-function SheetClose({
-						...props
-					}: React.ComponentProps<typeof SheetPrimitive.Close>) {
-	return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+function SheetClose({ ...props }: React.ComponentProps<typeof SheetPrimitive.Close>) {
+	return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
 }
 
-function SheetPortal({
-						 ...props
-					 }: React.ComponentProps<typeof SheetPrimitive.Portal>) {
-	return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+function SheetPortal({ ...props }: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+	return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
 }
 
-function SheetOverlay({
-						  className,
-						  ...props
-					  }: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+function SheetOverlay({ className, ...props }: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
 	return (
 		<SheetPrimitive.Overlay
 			data-slot="sheet-overlay"
@@ -41,100 +32,62 @@ function SheetOverlay({
 			)}
 			{...props}
 		/>
-	)
+	);
 }
 
 function SheetContent({
-						  className,
-						  children,
-						  side = "right",
-						  ...props
-					  }: React.ComponentProps<typeof SheetPrimitive.Content> & {
-	side?: "top" | "right" | "bottom" | "left"
+	className,
+	children,
+	side = "right",
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+	side?: "top" | "right" | "bottom" | "left";
 }) {
 	return (
 		<SheetPortal>
-			<SheetOverlay/>
+			<SheetOverlay />
 			<SheetPrimitive.Content
 				data-slot="sheet-content"
 				className={cn(
 					"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
 					side === "right" &&
-					"data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+						"data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
 					side === "left" &&
-					"data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+						"data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
 					side === "top" &&
-					"data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+						"data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
 					side === "bottom" &&
-					"data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+						"data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
 					className
 				)}
 				{...props}
 			>
 				{children}
-				<SheetPrimitive.Close
-					className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-					<XIcon className="size-4"/>
+				<SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+					<XIcon className="size-4" />
 					<span className="sr-only">Close</span>
 				</SheetPrimitive.Close>
 			</SheetPrimitive.Content>
 		</SheetPortal>
-	)
+	);
 }
 
-function SheetHeader({className, ...props}: React.ComponentProps<"div">) {
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return <div data-slot="sheet-header" className={cn("flex flex-col gap-1.5 p-4", className)} {...props} />;
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+	return <div data-slot="sheet-footer" className={cn("mt-auto flex flex-col gap-2 p-4", className)} {...props} />;
+}
+
+function SheetTitle({ className, ...props }: React.ComponentProps<typeof SheetPrimitive.Title>) {
+	return <SheetPrimitive.Title data-slot="sheet-title" className={cn("text-foreground font-semibold", className)} {...props} />;
+}
+
+function SheetDescription({ className, ...props }: React.ComponentProps<typeof SheetPrimitive.Description>) {
 	return (
-		<div
-			data-slot="sheet-header"
-			className={cn("flex flex-col gap-1.5 p-4", className)}
-			{...props}
-		/>
-	)
+		<SheetPrimitive.Description data-slot="sheet-description" className={cn("text-muted-foreground text-sm", className)} {...props} />
+	);
 }
 
-function SheetFooter({className, ...props}: React.ComponentProps<"div">) {
-	return (
-		<div
-			data-slot="sheet-footer"
-			className={cn("mt-auto flex flex-col gap-2 p-4", className)}
-			{...props}
-		/>
-	)
-}
-
-function SheetTitle({
-						className,
-						...props
-					}: React.ComponentProps<typeof SheetPrimitive.Title>) {
-	return (
-		<SheetPrimitive.Title
-			data-slot="sheet-title"
-			className={cn("text-foreground font-semibold", className)}
-			{...props}
-		/>
-	)
-}
-
-function SheetDescription({
-							  className,
-							  ...props
-						  }: React.ComponentProps<typeof SheetPrimitive.Description>) {
-	return (
-		<SheetPrimitive.Description
-			data-slot="sheet-description"
-			className={cn("text-muted-foreground text-sm", className)}
-			{...props}
-		/>
-	)
-}
-
-export {
-	Sheet,
-	SheetTrigger,
-	SheetClose,
-	SheetContent,
-	SheetHeader,
-	SheetFooter,
-	SheetTitle,
-	SheetDescription,
-}
+export { Sheet, SheetTrigger, SheetClose, SheetContent, SheetHeader, SheetFooter, SheetTitle, SheetDescription };

--- a/web/components/ui/skeleton.tsx
+++ b/web/components/ui/skeleton.tsx
@@ -1,13 +1,7 @@
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function Skeleton({className, ...props}: React.ComponentProps<"div">) {
-	return (
-		<div
-			data-slot="skeleton"
-			className={cn("bg-accent animate-pulse rounded-md", className)}
-			{...props}
-		/>
-	)
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+	return <div data-slot="skeleton" className={cn("bg-accent animate-pulse rounded-md", className)} {...props} />;
 }
 
-export {Skeleton}
+export { Skeleton };

--- a/web/components/ui/sonner.tsx
+++ b/web/components/ui/sonner.tsx
@@ -1,10 +1,10 @@
-"use client"
+"use client";
 
-import {useTheme} from "next-themes"
-import {Toaster as Sonner, ToasterProps} from "sonner"
+import { useTheme } from "next-themes";
+import { Toaster as Sonner, ToasterProps } from "sonner";
 
-const Toaster = ({...props}: ToasterProps) => {
-	const {theme = "system"} = useTheme()
+const Toaster = ({ ...props }: ToasterProps) => {
+	const { theme = "system" } = useTheme();
 
 	return (
 		<Sonner
@@ -19,7 +19,7 @@ const Toaster = ({...props}: ToasterProps) => {
 			}
 			{...props}
 		/>
-	)
-}
+	);
+};
 
-export {Toaster}
+export { Toaster };

--- a/web/components/ui/toggle.tsx
+++ b/web/components/ui/toggle.tsx
@@ -1,10 +1,10 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as TogglePrimitive from "@radix-ui/react-toggle"
-import {cva, type VariantProps} from "class-variance-authority"
+import * as React from "react";
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const toggleVariants = cva(
 	"inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
@@ -12,8 +12,7 @@ const toggleVariants = cva(
 		variants: {
 			variant: {
 				default: "bg-transparent",
-				outline:
-					"border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+				outline: "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
 			},
 			size: {
 				default: "h-9 px-2 min-w-9",
@@ -26,22 +25,15 @@ const toggleVariants = cva(
 			size: "default",
 		},
 	}
-)
+);
 
 function Toggle({
-					className,
-					variant,
-					size,
-					...props
-				}: React.ComponentProps<typeof TogglePrimitive.Root> &
-	VariantProps<typeof toggleVariants>) {
-	return (
-		<TogglePrimitive.Root
-			data-slot="toggle"
-			className={cn(toggleVariants({variant, size, className}))}
-			{...props}
-		/>
-	)
+	className,
+	variant,
+	size,
+	...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>) {
+	return <TogglePrimitive.Root data-slot="toggle" className={cn(toggleVariants({ variant, size, className }))} {...props} />;
 }
 
-export {Toggle, toggleVariants}
+export { Toggle, toggleVariants };

--- a/web/components/ui/tooltip.tsx
+++ b/web/components/ui/tooltip.tsx
@@ -1,45 +1,27 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function TooltipProvider({
-							 delayDuration = 0,
-							 ...props
-						 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
-	return (
-		<TooltipPrimitive.Provider
-			data-slot="tooltip-provider"
-			delayDuration={delayDuration}
-			{...props}
-		/>
-	)
+function TooltipProvider({ delayDuration = 0, ...props }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+	return <TooltipPrimitive.Provider data-slot="tooltip-provider" delayDuration={delayDuration} {...props} />;
 }
 
-function Tooltip({
-					 ...props
-				 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
 	return (
 		<TooltipProvider>
 			<TooltipPrimitive.Root data-slot="tooltip" {...props} />
 		</TooltipProvider>
-	)
+	);
 }
 
-function TooltipTrigger({
-							...props
-						}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-	return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+	return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
-function TooltipContent({
-							className,
-							sideOffset = 0,
-							children,
-							...props
-						}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+function TooltipContent({ className, sideOffset = 0, children, ...props }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
 	return (
 		<TooltipPrimitive.Portal>
 			<TooltipPrimitive.Content
@@ -52,11 +34,10 @@ function TooltipContent({
 				{...props}
 			>
 				{children}
-				<TooltipPrimitive.Arrow
-					className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]"/>
+				<TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
 			</TooltipPrimitive.Content>
 		</TooltipPrimitive.Portal>
-	)
+	);
 }
 
-export {Tooltip, TooltipTrigger, TooltipContent, TooltipProvider}
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+	return twMerge(clsx(inputs));
 }

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,15 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-    images: {
-        remotePatterns: [
-            new URL("https://s4.anilist.co/file/anilistcdn/media/**/*.*"),
-            new URL("https://image.tmdb.org/t/p/**/*.*")
-        ]
-    },
-    reactStrictMode: false,
-    output: "standalone"
+	images: {
+		remotePatterns: [new URL("https://s4.anilist.co/file/anilistcdn/media/**/*.*"), new URL("https://image.tmdb.org/t/p/**/*.*")],
+	},
+	reactStrictMode: false,
+	output: "standalone",
 };
 
 export default nextConfig;
-

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,41 +1,27 @@
 {
-  "compilerOptions": {
-    "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@/*": [
-        "./*"
-      ]
-    }
-  },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+	"compilerOptions": {
+		"target": "ES2017",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"allowJs": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"jsx": "react-jsx",
+		"incremental": true,
+		"plugins": [
+			{
+				"name": "next"
+			}
+		],
+		"paths": {
+			"@/*": ["./*"]
+		}
+	},
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
+	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- Add .prettierrc with tab indentation, 4-space tab width, 140 print width
- Add .prettierignore for build artifacts and dependencies
- Reformat all web/ TypeScript/TSX/CSS/JSON files
- Consistent code style across the frontend codebase

Part of #12 split.