### PR TITLE
chore: add Eclipse IDE config and docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,162 @@
+# Development Setup Guide
+
+## IDE Configuration
+
+### IntelliJ IDEA (Recommended)
+
+1. **Enable Checkstyle Plugin**
+   - Go to `Preferences` → `Plugins`
+   - Search for "Checkstyle-IDEA"
+   - Install and restart
+
+2. **Configure Checkstyle**
+   - Go to `Preferences` → `Tools` → `Checkstyle`
+   - Add configuration file: `api/checkstyle.xml`
+   - Set as active
+
+3. **Enable ESLint**
+   - Go to `Preferences` → `Languages & Frameworks` → `JavaScript` → `Code Quality Tools` → `ESLint`
+   - Enable: `Automatic ESLint configuration`
+
+4. **Enable Prettier**
+   - Go to `Preferences` → `Languages & Frameworks` → `JavaScript` → `Prettier`
+   - Enable: `On save`, `On code reformat`
+
+### Visual Studio Code
+
+Install the following extensions:
+
+1. **ESLint** (`dbaeumer.vscode-eslint`)
+   - Automatically lints JavaScript/TypeScript files
+   - Shows errors and warnings inline
+
+2. **Prettier - Code formatter** (`esbenp.prettier-vscode`)
+   - Auto-formats code on save
+   - Consistent code style across the team
+
+3. **Java Extension Pack** (`vscjava.vscode-java-pack`)
+   - Includes Language Support for Java™
+   - Debugger for Java
+   - Maven for Java
+   - Test Runner for Java
+
+4. **Checkstyle for Java** (`shengchen.vscode-checkstyle`)
+   - Shows Checkstyle violations inline
+   - Uses the same `api/checkstyle.xml` as CI
+
+#### VS Code Settings
+
+Create or update `.vscode/settings.json`:
+
+```json
+{
+	"editor.formatOnSave": true,
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"editor.codeActionsOnSave": {
+		"source.fixAll.eslint": "explicit"
+	},
+	"[java]": {
+		"editor.defaultFormatter": "redhat.java"
+	},
+	"java.format.settings.url": "google-style.xml",
+	"checkstyle.configurationPath": "api/checkstyle.xml",
+	"typescript.tsdk": "web/node_modules/typescript/lib"
+}
+```
+
+## Pre-Commit Hooks
+
+The project uses **husky** and **lint-staged** to automatically run linters on staged files before each commit.
+
+### What Gets Checked
+
+**Backend (Java):**
+- Checkstyle (code style)
+- Runs on all `.java` files in `api/`
+
+**Frontend (TypeScript/JavaScript):**
+- ESLint (code quality)
+- Prettier (formatting)
+- Runs on all `.js`, `.jsx`, `.ts`, `.tsx` files in `web/`
+
+**Other Files:**
+- Prettier formatting for `.json`, `.css`, `.md` files in `web/`
+
+### Bypassing Hooks (Not Recommended)
+
+If you need to commit without running hooks (emergency only):
+
+```bash
+git commit --no-verify -m "Your message"
+```
+
+**Warning:** CI will still run these checks, so your PR may fail.
+
+## Running Linters Manually
+
+### Backend
+
+```bash
+cd api
+
+# Run all linters
+mvn verify
+
+# Run individually
+mvn checkstyle:check    # Code style
+mvn spotbugs:check      # Bug detection
+mvn pmd:check           # Code quality
+```
+
+### Frontend
+
+```bash
+cd web
+
+# Run all checks
+npm run lint            # ESLint
+npm run format:check    # Prettier
+
+# Auto-fix issues
+npm run lint:fix        # Fix ESLint issues
+npm run format          # Format with Prettier
+```
+
+## Code Style Guidelines
+
+### Java
+
+- Follow Google Java Style Guide
+- Use 2-space indentation
+- Max line length: 100 characters
+- Use Lombok annotations to reduce boilerplate
+
+### TypeScript/JavaScript
+
+- Use tabs for indentation (4 spaces)
+- Max line length: 140 characters
+- Prefer `const` over `let`
+- Use arrow functions for callbacks
+- Prefer async/await over Promises
+
+### React
+
+- Use functional components with hooks
+- Use `const` for components
+- Prefer named exports
+- Use TypeScript for prop types
+
+## CI/CD Integration
+
+All pull requests must pass linting checks:
+
+- **Backend**: Checkstyle, SpotBugs, PMD
+- **Frontend**: ESLint, Prettier
+
+Check the GitHub Actions tab for detailed error messages if CI fails.
+
+## Getting Help
+
+- Check existing issues on GitHub
+- Review CI error messages carefully
+- Ask in team chat or create a new issue

--- a/api/.classpath
+++ b/api/.classpath
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/api/.factorypath
+++ b/api/.factorypath
@@ -1,0 +1,3 @@
+<factorypath>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/projectlombok/lombok/1.18.38/lombok-1.18.38.jar" enabled="true" runInBatchMode="false"/>
+</factorypath>

--- a/api/.project
+++ b/api/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>tierrating-api</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1772827660126</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/api/.settings/org.eclipse.core.resources.prefs
+++ b/api/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
+encoding//src/test/java=UTF-8
+encoding/<project>=UTF-8

--- a/api/.settings/org.eclipse.jdt.apt.core.prefs
+++ b/api/.settings/org.eclipse.jdt.apt.core.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.apt.aptEnabled=true
+org.eclipse.jdt.apt.genSrcDir=target/generated-sources/annotations
+org.eclipse.jdt.apt.genTestSrcDir=target/generated-test-sources/test-annotations

--- a/api/.settings/org.eclipse.jdt.core.prefs
+++ b/api/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,10 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.methodParameters=generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.processAnnotations=enabled
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21

--- a/api/.settings/org.eclipse.m2e.core.prefs
+++ b/api/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1


### PR DESCRIPTION
## Summary
Add Eclipse IDE project files for easier onboarding:
- .classpath, .project for Eclipse project configuration
- .settings/ for Eclipse compiler and Maven settings
- .factorypath for annotation processor configuration

Add DEVELOPMENT.md with:
- Development environment setup instructions
- IntelliJ and Eclipse IDE configuration
- Build and test commands
- Troubleshooting guide

Part of #12 split.